### PR TITLE
Class destructor access specifier

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -15,6 +15,7 @@
 #include "ClassMemberRedefinedCheck.h"
 #include "ClassVirtualBaseCheck.h"
 #include "DeclForbiddenCheck.h"
+#include "DestructorAccessSpecifierCheck.h"
 #include "EnumExplicitCheck.h"
 #include "EnumInitCheck.h"
 #include "EnumScopedCheck.h"
@@ -67,6 +68,8 @@ public:
         "bsl-class-virtual-base");
     CheckFactories.registerCheck<DeclForbiddenCheck>(
         "bsl-decl-forbidden");
+    CheckFactories.registerCheck<DestructorAccessSpecifierCheck>(
+        "bsl-destructor-access-specifier");
     CheckFactories.registerCheck<EnumExplicitCheck>(
         "bsl-enum-explicit");
     CheckFactories.registerCheck<EnumInitCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -9,6 +9,7 @@ add_clang_library(clangTidyBslModule
   ClassMemberRedefinedCheck.cpp
   ClassVirtualBaseCheck.cpp
   DeclForbiddenCheck.cpp
+  DestructorAccessSpecifierCheck.cpp
   EnumExplicitCheck.cpp
   EnumInitCheck.cpp
   EnumScopedCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.cpp
@@ -1,0 +1,53 @@
+//===--- DestructorAccessSpecifierCheck.cpp - clang-tidy ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DestructorAccessSpecifierCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+void DestructorAccessSpecifierCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(cxxDestructorDecl( 
+                    unless(anyOf(cxxDestructorDecl(isPublic(), isVirtual()),    // remove
+                           cxxDestructorDecl(isPublic(), isOverride()),
+                           cxxDestructorDecl(isProtected(), unless(isVirtual()))
+                    ))).bind("destructor"), this);
+
+  Finder->addMatcher(cxxDestructorDecl(isPublic(), unless(isVirtual())).bind("nonvirtual"), this);
+}
+
+void DestructorAccessSpecifierCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto Mgr = Result.SourceManager;
+  
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<CXXDestructorDecl>("destructor");
+  if (MatchedDecl) {
+    auto Loc = MatchedDecl->getLocation();
+    if (Mgr->getFileID(Loc) != Mgr->getMainFileID())
+      return;
+    diag(Loc, "base class destructor must be public virtual, public override, or protected non-virtual");
+  }
+
+  const auto *VDecl = Result.Nodes.getNodeAs<CXXDestructorDecl>("nonvirtual");
+  if (VDecl) {
+    auto LocV = VDecl->getLocation();
+    if (Mgr->getFileID(LocV) != Mgr->getMainFileID())
+      return;
+    if (!VDecl->getParent()->isEffectivelyFinal())
+      diag(LocV, "if public destructor is nonvirtual, then class must be declared final");
+  }
+  
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.cpp
@@ -18,7 +18,7 @@ namespace bsl {
 
 void DestructorAccessSpecifierCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(cxxDestructorDecl( 
-                    unless(anyOf(cxxDestructorDecl(isPublic(), isVirtual()),    // remove
+                    unless(anyOf(cxxDestructorDecl(isPublic()),
                            cxxDestructorDecl(isPublic(), isOverride()),
                            cxxDestructorDecl(isProtected(), unless(isVirtual()))
                     ))).bind("destructor"), this);
@@ -43,7 +43,7 @@ void DestructorAccessSpecifierCheck::check(const MatchFinder::MatchResult &Resul
     if (Mgr->getFileID(LocV) != Mgr->getMainFileID())
       return;
     if (!VDecl->getParent()->isEffectivelyFinal())
-      diag(LocV, "if public destructor is nonvirtual, then class must be declared final");
+      diag(LocV, "if public destructor is nonvirtual, then class must be declared final. Destructor of base class should be public virtual");
   }
   
 }

--- a/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.h
@@ -1,0 +1,34 @@
+//===--- DestructorAccessSpecifierCheck.h - clang-tidy ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_DESTRUCTORACCESSSPECIFIERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_DESTRUCTORACCESSSPECIFIERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-destructor-access-specifier.html
+class DestructorAccessSpecifierCheck : public ClangTidyCheck {
+public:
+  DestructorAccessSpecifierCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_DESTRUCTORACCESSSPECIFIERCHECK_H

--- a/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.h
@@ -15,7 +15,9 @@ namespace clang {
 namespace tidy {
 namespace bsl {
 
-/// FIXME: Write a short description.
+/// Check that destructor base class is public virtual, public override, or
+/// protected non-virtual. If public destructor has non-virtual class, then
+/// declare class as final
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/bsl-destructor-access-specifier.html

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -114,7 +114,8 @@ New checks
 - New :doc:`bsl-destructor-access-specifier
   <clang-tidy/checks/bsl-destructor-access-specifier>` check.
 
-  FIXME: add release notes.
+  Warns if destructor of base class is not public virtual, public override, 
+  or protected non-virtual, unless public destructor is non-virtual in final class.
 
 - New :doc:`bsl-friend-decl
   <clang-tidy/checks/bsl-friend-decl>` check.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -111,6 +111,11 @@ New checks
 
   Warns if unions or bitfields are declared.
 
+- New :doc:`bsl-destructor-access-specifier
+  <clang-tidy/checks/bsl-destructor-access-specifier>` check.
+
+  FIXME: add release notes.
+
 - New :doc:`bsl-friend-decl
   <clang-tidy/checks/bsl-friend-decl>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-destructor-access-specifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-destructor-access-specifier.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - bsl-destructor-access-specifier
+
+bsl-destructor-access-specifier
+===============================
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-destructor-access-specifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-destructor-access-specifier.rst
@@ -3,4 +3,83 @@
 bsl-destructor-access-specifier
 ===============================
 
-FIXME: Describe what patterns does the check detect and why. Give examples.
+Warns if destructor of base class is not public virtual, public override, 
+or protected non-virtual, unless public destructor is non-virtual in final class.
+
+Example:
+
+.. code-block:: c++
+
+class A {	// Warning
+public:
+  ~A(){}
+};
+
+class B : public A {};	// Warning
+
+class C {	// No warning
+public:
+  virtual ~C()
+  {}
+};
+
+class D : public C {};
+
+class E { 	// No warning
+protected:
+  ~E();
+};
+
+class F 	// Warning
+{
+public:
+  ~F() = default;
+};
+
+class G final	// No warning
+{
+public:
+  ~G() = default;
+};
+
+class H		// Warning
+{
+public:
+  virtual ~H() = default;
+};
+
+class I : public F {};	// Warning
+
+class J : public H {};
+
+class K : H 	// No warning
+{
+public:
+  ~K() override = default;
+};
+
+class L : H 	// Warning
+{
+private:
+  ~L() override = default;
+};
+
+
+template <typename T> class X { // Non-compliant
+private:
+  T t;
+
+public:		// Warning
+  T get_t() { return t; }
+  ~X() = default;
+};
+
+template <typename T> class Y final {	// No warning
+public:
+  ~Y() = default; 
+};
+
+template <typename T> class Z {		// No warning
+public:
+  virtual ~Z() = default; 
+};

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -51,6 +51,7 @@ Clang-Tidy Checks
    `bsl-class-member-redefined <bsl-class-member-redefined.html>`_,
    `bsl-class-virtual-base <bsl-class-virtual-base.html>`_,
    `bsl-decl-forbidden <bsl-decl-forbidden.html>`_,
+   `bsl-destructor-access-specifier <bsl-destructor-access-specifier.html>`_, "Yes"
    `bsl-enum-explicit <bsl-enum-explicit.html>`_,
    `bsl-enum-init <bsl-enum-init.html>`_,
    `bsl-enum-scoped <bsl-enum-scoped.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
@@ -1,72 +1,82 @@
 // RUN: %check_clang_tidy %s bsl-destructor-access-specifier %t
 
-class A
-{
-  public:
-    ~A() // Non-compliant
-    {
-    }
+class A { // Non-compliant
+public:
+  ~A()
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+  {}
 };
 
-class B : public A
-{
+class B : public A {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+
+class C { // Compliant
+public:
+  virtual ~C()
+  {}
 };
 
-class C
-{
-  public:
-    virtual ~C() // Compliant
-    {
-    }
+class D : public C {};
+
+class E { // Compliant
+protected:
+  ~E();
 };
 
-class D : public C
-{
-};
-
-class E
-{
-  protected:
-    ~E(); // Compliant
-};
-
-
-class F  		// non-compliant
+class F // Non-compliant
 {
 public:
-	~F() = default;
+  ~F() = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
 };
 
-class G final	// compliant
+class G final // Compliant
 {
 public:
-	~G() = default;
+  ~G() = default;
 };
 
-class H		// compliant
+class H // Compliant
 {
 public:
-	virtual ~H() = default;
+  virtual ~H() = default;
 };
 
-class I: public F
+class I : public F {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+
+class J : public H {};
+
+class K : H // compliant
 {
+public:
+  ~K() override = default;
 };
 
-class J: public H {};
-
-
-template <typename T>
-class X {
+class L : H // Non-compliant
+{
 private:
-    T t;
-public:
-    T get_t() { return t; }
-    ~X() = default; // non-compliant, class is not final
+  ~L() override = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
 };
 
-int foo()
-{
-    X<int> x;
-   return x.get_t();
-}
+
+template <typename T> class X { // Non-compliant
+private:
+  T t;
+
+public:
+  T get_t() { return t; }
+  ~X() = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+};
+
+template <typename T> class Y final {
+public:
+  ~Y() = default; 
+};
+
+template <typename T> class Z {
+public:
+  virtual ~Z() = default; 
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
@@ -12,7 +12,7 @@ class B : public A
 {
 };
 
-clewass C
+class C
 {
   public:
     virtual ~C() // Compliant

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
@@ -1,0 +1,57 @@
+// RUN: %check_clang_tidy %s bsl-destructor-access-specifier %t
+
+class A
+{
+  public:
+    ~A() // Non-compliant
+    {
+    }
+};
+
+class B : public A
+{
+};
+
+class C
+{
+  public:
+    virtual ~C() // Compliant
+    {
+    }
+};
+
+class D : public C
+{
+};
+
+class E
+{
+  protected:
+    ~E(); // Compliant
+};
+
+
+class F  		// non-compliant
+{
+public:
+	~F() = default;
+};
+
+class G final	// compliant
+{
+public:
+	~G() = default;
+};
+
+class H		// compliant
+{
+public:
+	virtual ~H() = default;
+};
+
+class I: public F
+{
+};
+
+class J: public H {};
+

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
@@ -55,3 +55,18 @@ class I: public F
 
 class J: public H {};
 
+
+template <typename T>
+class X {
+private:
+    T t;
+public:
+    T get_t() { return t; }
+    ~X() = default; // non-compliant, class is not final
+};
+
+int foo()
+{
+    X<int> x;
+   return x.get_t();
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
@@ -12,7 +12,7 @@ class B : public A
 {
 };
 
-class C
+clewass C
 {
   public:
     virtual ~C() // Compliant


### PR DESCRIPTION
Destructor of a base class shall be public virtual, public override or protected non-virtual. If a public destructor of a class is non-virtual, then the class should be declared final.