### PR TITLE
[clang-tidy] Add bsl-special-member-functions

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -48,6 +48,7 @@
 #include "OpMixedIncrementDecrementCheck.h"
 #include "OpRelationalReturnBoolCheck.h"
 #include "PureOverrideCheck.h"
+#include "SpecialMemberFunctionsCheck.h"
 #include "StmtForbiddenCheck.h"
 #include "StmtSwitchCaseParentCheck.h"
 #include "StmtSwitchDefaultBreakCheck.h"
@@ -139,6 +140,8 @@ public:
         "bsl-op-relational-return-bool");
     CheckFactories.registerCheck<PureOverrideCheck>(
         "bsl-pure-override");
+    CheckFactories.registerCheck<SpecialMemberFunctionsCheck>(
+        "bsl-special-member-functions");
     CheckFactories.registerCheck<StmtForbiddenCheck>(
         "bsl-stmt-forbidden");
     CheckFactories.registerCheck<StmtSwitchCaseParentCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -42,6 +42,7 @@ add_clang_library(clangTidyBslModule
   OpMixedIncrementDecrementCheck.cpp
   OpRelationalReturnBoolCheck.cpp
   PureOverrideCheck.cpp
+  SpecialMemberFunctionsCheck.cpp
   StmtForbiddenCheck.cpp
   StmtSwitchCaseParentCheck.cpp
   StmtSwitchDefaultBreakCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/SpecialMemberFunctionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/SpecialMemberFunctionsCheck.cpp
@@ -1,0 +1,213 @@
+//===--- SpecialMemberFunctionsCheck.cpp - clang-tidy ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SpecialMemberFunctionsCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+SpecialMemberFunctionsCheck::SpecialMemberFunctionsCheck(
+    StringRef Name, ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      AllowMissingMoveFunctions(Options.get("AllowMissingMoveFunctions", 0)),
+      AllowSoleDefaultDtor(Options.get("AllowSoleDefaultDtor", 0)),
+      AllowMissingMoveFunctionsWhenCopyIsDeleted(
+          Options.get("AllowMissingMoveFunctionsWhenCopyIsDeleted", 0)) {}
+
+void SpecialMemberFunctionsCheck::storeOptions(
+    ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "AllowMissingMoveFunctions", AllowMissingMoveFunctions);
+  Options.store(Opts, "AllowSoleDefaultDtor", AllowSoleDefaultDtor);
+  Options.store(Opts, "AllowMissingMoveFunctionsWhenCopyIsDeleted",
+                AllowMissingMoveFunctionsWhenCopyIsDeleted);
+}
+
+void SpecialMemberFunctionsCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      cxxRecordDecl(
+          eachOf(
+              has(cxxConstructorDecl(isDefaultConstructor(),
+                                     unless(isImplicit()))
+                      .bind("ctor")),
+              has(cxxDestructorDecl(unless(anyOf(isImplicit(), isVirtual()))).bind("dtor")),
+              has(cxxConstructorDecl(isCopyConstructor(), unless(isImplicit()))
+                      .bind("copy-ctor")),
+              has(cxxMethodDecl(isCopyAssignmentOperator(),
+                                unless(isImplicit()))
+                      .bind("copy-assign")),
+              has(cxxConstructorDecl(isMoveConstructor(), unless(isImplicit()))
+                      .bind("move-ctor")),
+              has(cxxMethodDecl(isMoveAssignmentOperator(),
+                                unless(isImplicit()))
+                      .bind("move-assign"))))
+          .bind("class-def"),
+      this);
+}
+
+static llvm::StringRef
+toString(SpecialMemberFunctionsCheck::SpecialMemberFunctionKind K) {
+  switch (K) {
+  case SpecialMemberFunctionsCheck::SpecialMemberFunctionKind::
+      DefaultConstructor:
+    return "a default constructor";
+  case SpecialMemberFunctionsCheck::SpecialMemberFunctionKind::Destructor:
+    return "a destructor";
+  case SpecialMemberFunctionsCheck::SpecialMemberFunctionKind::
+      DefaultDestructor:
+    return "a default destructor";
+  case SpecialMemberFunctionsCheck::SpecialMemberFunctionKind::
+      NonDefaultDestructor:
+    return "a non-default destructor";
+  case SpecialMemberFunctionsCheck::SpecialMemberFunctionKind::CopyConstructor:
+    return "a copy constructor";
+  case SpecialMemberFunctionsCheck::SpecialMemberFunctionKind::CopyAssignment:
+    return "a copy assignment operator";
+  case SpecialMemberFunctionsCheck::SpecialMemberFunctionKind::MoveConstructor:
+    return "a move constructor";
+  case SpecialMemberFunctionsCheck::SpecialMemberFunctionKind::MoveAssignment:
+    return "a move assignment operator";
+  }
+  llvm_unreachable("Unhandled SpecialMemberFunctionKind");
+}
+
+static std::string
+join(ArrayRef<SpecialMemberFunctionsCheck::SpecialMemberFunctionKind> SMFS,
+     llvm::StringRef AndOr) {
+
+  assert(!SMFS.empty() &&
+         "List of defined or undefined members should never be empty.");
+  std::string Buffer;
+  llvm::raw_string_ostream Stream(Buffer);
+
+  Stream << toString(SMFS[0]);
+  size_t LastIndex = SMFS.size() - 1;
+  for (size_t i = 1; i < LastIndex; ++i) {
+    Stream << ", " << toString(SMFS[i]);
+  }
+  if (LastIndex != 0) {
+    Stream << AndOr << toString(SMFS[LastIndex]);
+  }
+  return Stream.str();
+}
+
+void SpecialMemberFunctionsCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<CXXRecordDecl>("class-def");
+  if (!MatchedDecl)
+    return;
+
+  ClassDefId ID(MatchedDecl->getLocation(),
+                std::string(MatchedDecl->getName()));
+
+  auto StoreMember = [this, &ID](SpecialMemberFunctionData data) {
+    llvm::SmallVectorImpl<SpecialMemberFunctionData> &Members =
+        ClassWithSpecialMembers[ID];
+    if (!llvm::is_contained(Members, data))
+      Members.push_back(std::move(data));
+  };
+
+  if (const auto *Dtor = Result.Nodes.getNodeAs<CXXMethodDecl>("dtor")) {
+    StoreMember({Dtor->isDefaulted()
+                     ? SpecialMemberFunctionKind::DefaultDestructor
+                     : SpecialMemberFunctionKind::NonDefaultDestructor,
+                 Dtor->isDeleted()});
+  }
+
+  std::initializer_list<std::pair<std::string, SpecialMemberFunctionKind>>
+      Matchers = {{"copy-ctor", SpecialMemberFunctionKind::CopyConstructor},
+                  {"copy-assign", SpecialMemberFunctionKind::CopyAssignment},
+                  {"move-ctor", SpecialMemberFunctionKind::MoveConstructor},
+                  {"move-assign", SpecialMemberFunctionKind::MoveAssignment},
+                  {"ctor", SpecialMemberFunctionKind::DefaultConstructor}};
+
+  for (const auto &KV : Matchers)
+    if (const auto *MethodDecl =
+            Result.Nodes.getNodeAs<CXXMethodDecl>(KV.first)) {
+      StoreMember({KV.second, MethodDecl->isDeleted()});
+    }
+}
+
+void SpecialMemberFunctionsCheck::onEndOfTranslationUnit() {
+  for (const auto &C : ClassWithSpecialMembers) {
+    checkForMissingMembers(C.first, C.second);
+  }
+}
+
+void SpecialMemberFunctionsCheck::checkForMissingMembers(
+    const ClassDefId &ID,
+    llvm::ArrayRef<SpecialMemberFunctionData> DefinedMembers) {
+  llvm::SmallVector<SpecialMemberFunctionKind, 5> MissingMembers;
+
+  auto HasMember = [&](SpecialMemberFunctionKind Kind) {
+    return llvm::any_of(DefinedMembers, [Kind](const auto &data) {
+      return data.FunctionKind == Kind;
+    });
+  };
+
+  auto IsDeleted = [&](SpecialMemberFunctionKind Kind) {
+    return llvm::any_of(DefinedMembers, [Kind](const auto &data) {
+      return data.FunctionKind == Kind && data.IsDeleted;
+    });
+  };
+
+  auto RequireMember = [&](SpecialMemberFunctionKind Kind) {
+    if (!HasMember(Kind))
+      MissingMembers.push_back(Kind);
+  };
+
+  bool RequireThree =
+      HasMember(SpecialMemberFunctionKind::NonDefaultDestructor) ||
+      (!AllowSoleDefaultDtor &&
+       HasMember(SpecialMemberFunctionKind::DefaultDestructor)) ||
+      HasMember(SpecialMemberFunctionKind::CopyConstructor) ||
+      HasMember(SpecialMemberFunctionKind::CopyAssignment) ||
+      HasMember(SpecialMemberFunctionKind::MoveConstructor) ||
+      HasMember(SpecialMemberFunctionKind::MoveAssignment) ||
+      HasMember(SpecialMemberFunctionKind::DefaultConstructor);
+
+  bool RequireFive = (!AllowMissingMoveFunctions && RequireThree &&
+                      getLangOpts().CPlusPlus11) ||
+                     HasMember(SpecialMemberFunctionKind::MoveConstructor) ||
+                     HasMember(SpecialMemberFunctionKind::MoveAssignment);
+
+  if (RequireThree) {
+    if (!HasMember(SpecialMemberFunctionKind::DefaultDestructor) &&
+        !HasMember(SpecialMemberFunctionKind::NonDefaultDestructor))
+      MissingMembers.push_back(SpecialMemberFunctionKind::Destructor);
+
+    RequireMember(SpecialMemberFunctionKind::CopyConstructor);
+    RequireMember(SpecialMemberFunctionKind::CopyAssignment);
+  }
+
+  if (RequireFive &&
+      !(AllowMissingMoveFunctionsWhenCopyIsDeleted &&
+        (IsDeleted(SpecialMemberFunctionKind::CopyConstructor) &&
+         IsDeleted(SpecialMemberFunctionKind::CopyAssignment)))) {
+    assert(RequireThree);
+    RequireMember(SpecialMemberFunctionKind::MoveConstructor);
+    RequireMember(SpecialMemberFunctionKind::MoveAssignment);
+  }
+
+  if (!MissingMembers.empty()) {
+    llvm::SmallVector<SpecialMemberFunctionKind, 5> DefinedMemberKinds;
+    llvm::transform(DefinedMembers, std::back_inserter(DefinedMemberKinds),
+                    [](const auto &data) { return data.FunctionKind; });
+    diag(ID.first, "class '%0' defines %1 but does not define %2")
+        << ID.second << bsl::join(DefinedMemberKinds, " and ")
+        << bsl::join(MissingMembers, " or ");
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/SpecialMemberFunctionsCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/SpecialMemberFunctionsCheck.h
@@ -1,0 +1,115 @@
+//===--- SpecialMemberFunctionsCheck.h - clang-tidy -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_SPECIALMEMBERFUNCTIONSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_SPECIALMEMBERFUNCTIONSCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks for classes where some, but not all, of the special member functions
+/// are defined.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-special-member-functions.html
+class SpecialMemberFunctionsCheck : public ClangTidyCheck {
+public:
+  SpecialMemberFunctionsCheck(StringRef Name, ClangTidyContext *Context);
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void onEndOfTranslationUnit() override;
+
+  enum class SpecialMemberFunctionKind : uint8_t {
+    DefaultConstructor,
+    Destructor,
+    DefaultDestructor,
+    NonDefaultDestructor,
+    CopyConstructor,
+    CopyAssignment,
+    MoveConstructor,
+    MoveAssignment
+  };
+
+  struct SpecialMemberFunctionData {
+    SpecialMemberFunctionKind FunctionKind;
+    bool IsDeleted;
+
+    bool operator==(const SpecialMemberFunctionData &Other) {
+      return (Other.FunctionKind == FunctionKind) &&
+             (Other.IsDeleted == IsDeleted);
+    }
+  };
+
+  using ClassDefId = std::pair<SourceLocation, std::string>;
+
+  using ClassDefiningSpecialMembersMap =
+      llvm::DenseMap<ClassDefId,
+                     llvm::SmallVector<SpecialMemberFunctionData, 5>>;
+
+private:
+  void checkForMissingMembers(
+      const ClassDefId &ID,
+      llvm::ArrayRef<SpecialMemberFunctionData> DefinedSpecialMembers);
+
+  const bool AllowMissingMoveFunctions;
+  const bool AllowSoleDefaultDtor;
+  const bool AllowMissingMoveFunctionsWhenCopyIsDeleted;
+  ClassDefiningSpecialMembersMap ClassWithSpecialMembers;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+namespace llvm {
+/// Specialisation of DenseMapInfo to allow ClassDefId objects in DenseMaps
+/// FIXME: Move this to the corresponding cpp file as is done for
+/// clang-tidy/readability/IdentifierNamingCheck.cpp.
+template <>
+struct DenseMapInfo<clang::tidy::bsl::SpecialMemberFunctionsCheck::ClassDefId> {
+  using ClassDefId = clang::tidy::bsl::SpecialMemberFunctionsCheck::ClassDefId;
+
+  static inline ClassDefId getEmptyKey() {
+    return ClassDefId(
+        clang::SourceLocation::getFromRawEncoding(static_cast<unsigned>(-1)),
+        "EMPTY");
+  }
+
+  static inline ClassDefId getTombstoneKey() {
+    return ClassDefId(
+        clang::SourceLocation::getFromRawEncoding(static_cast<unsigned>(-2)),
+        "TOMBSTONE");
+  }
+
+  static unsigned getHashValue(ClassDefId Val) {
+    assert(Val != getEmptyKey() && "Cannot hash the empty key!");
+    assert(Val != getTombstoneKey() && "Cannot hash the tombstone key!");
+
+    std::hash<ClassDefId::second_type> SecondHash;
+    return Val.first.getRawEncoding() + SecondHash(Val.second);
+  }
+
+  static bool isEqual(const ClassDefId &LHS, const ClassDefId &RHS) {
+    if (RHS == getEmptyKey())
+      return LHS == getEmptyKey();
+    if (RHS == getTombstoneKey())
+      return LHS == getTombstoneKey();
+    return LHS == RHS;
+  }
+};
+
+} // namespace llvm
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_SPECIALMEMBERFUNCTIONSCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -251,6 +251,12 @@ New checks
 
   Warns if a pure virtual function overrides a non-pure function.
 
+- New :doc:`bsl-special-member-functions
+  <clang-tidy/checks/bsl-special-member-functions>` check.
+
+  Checks for classes where some, but not all, of the special member functions
+  are defined.
+
 - New :doc:`bsl-stmt-forbidden
   <clang-tidy/checks/bsl-stmt-forbidden>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-special-member-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-special-member-functions.rst
@@ -1,0 +1,64 @@
+.. title:: clang-tidy - bsl-special-member-functions
+
+bsl-special-member-functions
+============================
+
+The check finds classes where some but not all of the special member functions
+are defined.
+
+By default the compiler defines a copy constructor, copy assignment operator,
+move constructor, move assignment operator and destructor. The default can be
+suppressed by explicit user-definitions. The relationship between which
+functions will be suppressed by definitions of other functions is complicated
+and it is advised that all five are defaulted or explicitly defined.
+
+Note that defining a function with ``= delete`` is considered to be a
+definition.
+
+This rule is part of the "Constructors, assignments, and destructors" profile of the C++ Core
+Guidelines, corresponding to rule C.21. See
+
+https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all.
+
+Options
+-------
+
+.. option:: AllowSoleDefaultDtor
+
+   When set to `1` (default is `0`), this check doesn't flag classes with a sole, explicitly
+   defaulted destructor. An example for such a class is:
+   
+   .. code-block:: c++
+   
+     struct A {
+       virtual ~A() = default;
+     };
+   
+.. option:: AllowMissingMoveFunctions
+
+   When set to `1` (default is `0`), this check doesn't flag classes which define no move
+   operations at all. It still flags classes which define only one of either
+   move constructor or move assignment operator. With this option enabled, the following class won't be flagged:
+   
+   .. code-block:: c++
+   
+     struct A {
+       A(const A&);
+       A& operator=(const A&);
+       ~A();
+     };
+
+.. option:: AllowMissingMoveFunctionsWhenCopyIsDeleted
+
+   When set to `1` (default is `0`), this check doesn't flag classes which define deleted copy
+   operations but don't define move operations. This flags is related to Google C++ Style Guide
+   https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types. With this option enabled, the 
+   following class won't be flagged:
+   
+   .. code-block:: c++
+   
+     struct A {
+       A(const A&) = delete;
+       A& operator=(const A&) = delete;
+       ~A();
+     };

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -83,6 +83,7 @@ Clang-Tidy Checks
    `bsl-op-mixed-increment-decrement <bsl-op-mixed-increment-decrement.html>`_,
    `bsl-op-relational-return-bool <bsl-op-relational-return-bool.html>`_,
    `bsl-pure-override <bsl-pure-override.html>`_,
+   `bsl-special-member-functions <bsl-special-member-functions.html>`_,
    `bsl-stmt-forbidden <bsl-stmt-forbidden.html>`_,
    `bsl-stmt-switch-case-parent <bsl-stmt-switch-case-parent.html>`_,
    `bsl-stmt-switch-default-break <bsl-stmt-switch-default-break.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-special-member-functions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-special-member-functions.cpp
@@ -1,0 +1,143 @@
+// RUN: %check_clang_tidy %s bsl-special-member-functions %t
+
+class DefinesConstructor {
+  DefinesConstructor();
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesConstructor' defines a default constructor but does not define a destructor, a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DefinesDefaultedConstructor {
+  DefinesDefaultedConstructor() = default;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesDefaultedConstructor' defines a default constructor but does not define a destructor, a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DefinesDestructor {
+  ~DefinesDestructor();
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesDestructor' defines a non-default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DefinesDefaultedDestructor {
+  ~DefinesDefaultedDestructor() = default;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesDefaultedDestructor' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DefinesVirtualDestructor {
+  virtual ~DefinesVirtualDestructor() = 0;
+};
+
+class DefinesDefaultedVirtualDestructor {
+  virtual ~DefinesDefaultedVirtualDestructor() = default;
+};
+
+class DefinesCopyConstructor {
+  DefinesCopyConstructor(const DefinesCopyConstructor &);
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesCopyConstructor' defines a copy constructor but does not define a destructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DefinesDefaultedCopyConstructor {
+  DefinesDefaultedCopyConstructor(const DefinesDefaultedCopyConstructor &) = default;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesDefaultedCopyConstructor' defines a copy constructor but does not define a destructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DefinesCopyAssignment {
+  DefinesCopyAssignment &operator=(const DefinesCopyAssignment &);
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesCopyAssignment' defines a copy assignment operator but does not define a destructor, a copy constructor, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DefinesDefaultedCopyAssignment {
+  DefinesDefaultedCopyAssignment &operator=(const DefinesDefaultedCopyAssignment &) = default;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesDefaultedCopyAssignment' defines a copy assignment operator but does not define a destructor, a copy constructor, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DefinesMoveConstructor {
+  DefinesMoveConstructor(DefinesMoveConstructor &&);
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesMoveConstructor' defines a move constructor but does not define a destructor, a copy constructor, a copy assignment operator or a move assignment operator [bsl-special-member-functions]
+
+class DefinesDefaultedMoveConstructor {
+  DefinesDefaultedMoveConstructor(DefinesDefaultedMoveConstructor &&) = default;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesDefaultedMoveConstructor' defines a move constructor but does not define a destructor, a copy constructor, a copy assignment operator or a move assignment operator [bsl-special-member-functions]
+
+class DefinesMoveAssignment {
+  DefinesMoveAssignment &operator=(DefinesMoveAssignment &&);
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesMoveAssignment' defines a move assignment operator but does not define a destructor, a copy constructor, a copy assignment operator or a move constructor [bsl-special-member-functions]
+
+class DefinesDefaultedMoveAssignment {
+  DefinesDefaultedMoveAssignment &operator=(DefinesDefaultedMoveAssignment &&) = default;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DefinesDefaultedMoveAssignment' defines a move assignment operator but does not define a destructor, a copy constructor, a copy assignment operator or a move constructor [bsl-special-member-functions]
+
+
+class DeleteConstructor {
+  DeleteConstructor() = delete;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DeleteConstructor' defines a default constructor but does not define a destructor, a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DeleteDestructor {
+  ~DeleteDestructor() = delete;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DeleteDestructor' defines a non-default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DeleteCopyConstructor {
+  DeleteCopyConstructor(const DeleteCopyConstructor &) = delete;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DeleteCopyConstructor' defines a copy constructor but does not define a destructor, a copy assignment operator, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DeleteMoveConstructor {
+  DeleteMoveConstructor(DeleteMoveConstructor &&) = delete;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DeleteMoveConstructor' defines a move constructor but does not define a destructor, a copy constructor, a copy assignment operator or a move assignment operator [bsl-special-member-functions]
+
+class DeleteCopyAssignment {
+  DeleteCopyAssignment &operator=(const DeleteCopyAssignment &) = delete;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DeleteCopyAssignment' defines a copy assignment operator but does not define a destructor, a copy constructor, a move constructor or a move assignment operator [bsl-special-member-functions]
+
+class DeleteMoveAssignment {
+  DeleteMoveAssignment &operator=(DeleteMoveAssignment &&) = delete;
+};
+// CHECK-MESSAGES: [[@LINE-3]]:7: warning: class 'DeleteMoveAssignment' defines a move assignment operator but does not define a destructor, a copy constructor, a copy assignment operator or a move constructor [bsl-special-member-functions]
+
+
+class DefinesNothing {
+};
+
+class DefinesEverything {
+  DefinesEverything(const DefinesEverything &);
+  DefinesEverything &operator=(const DefinesEverything &);
+  DefinesEverything(DefinesEverything &&);
+  DefinesEverything &operator=(DefinesEverything &&);
+  ~DefinesEverything();
+};
+
+class DeletesEverything {
+  DeletesEverything(const DeletesEverything &) = delete;
+  DeletesEverything &operator=(const DeletesEverything &) = delete;
+  DeletesEverything(DeletesEverything &&) = delete;
+  DeletesEverything &operator=(DeletesEverything &&) = delete;
+  ~DeletesEverything() = delete;
+};
+
+class DeletesCopyDefaultsMove {
+  DeletesCopyDefaultsMove(const DeletesCopyDefaultsMove &) = delete;
+  DeletesCopyDefaultsMove &operator=(const DeletesCopyDefaultsMove &) = delete;
+  DeletesCopyDefaultsMove(DeletesCopyDefaultsMove &&) = default;
+  DeletesCopyDefaultsMove &operator=(DeletesCopyDefaultsMove &&) = default;
+  ~DeletesCopyDefaultsMove() = default;
+};
+
+template <typename T>
+struct TemplateClass {
+  TemplateClass() = default;
+  TemplateClass(const TemplateClass &);
+  TemplateClass &operator=(const TemplateClass &);
+  TemplateClass(TemplateClass &&);
+  TemplateClass &operator=(TemplateClass &&);
+  ~TemplateClass();
+};
+
+// Multiple instantiations of a class template will trigger multiple matches for defined special members.
+// This should not cause problems.
+TemplateClass<int> InstantiationWithInt;
+TemplateClass<double> InstantiationWithDouble;


### PR DESCRIPTION
A12-0-1
Checks for classes where some, but not all, of the special member functions are defined
Modified existing special-member-functions (added constructor)