### PR TITLE
Warns if std::move (or bsl::move) is used on objects declared const or const&

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -17,6 +17,7 @@
 #include "ClassVirtualBaseCheck.h"
 #include "ComparisonOperatorsForbiddenCheck.h"
 #include "CopyMoveAccessSpecifierCheck.h"
+#include "ConstObjStdMoveCheck.h"
 #include "DeclForbiddenCheck.h"
 #include "DestructorAccessSpecifierCheck.h"
 #include "ElseRequiredAfterIfCheck.h"
@@ -79,6 +80,8 @@ public:
         "bsl-comparison-operators-forbidden");
     CheckFactories.registerCheck<CopyMoveAccessSpecifierCheck>(
         "bsl-copy-move-access-specifier");
+    CheckFactories.registerCheck<ConstObjStdMoveCheck>(
+        "bsl-const-obj-std-move");
     CheckFactories.registerCheck<DeclForbiddenCheck>(
         "bsl-decl-forbidden");
     CheckFactories.registerCheck<DestructorAccessSpecifierCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -11,6 +11,7 @@ add_clang_library(clangTidyBslModule
   ClassVirtualBaseCheck.cpp
   ComparisonOperatorsForbiddenCheck.cpp
   CopyMoveAccessSpecifierCheck.cpp
+  ConstObjStdMoveCheck.cpp
   DeclForbiddenCheck.cpp
   DestructorAccessSpecifierCheck.cpp
   ElseRequiredAfterIfCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/ConstObjStdMoveCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/ConstObjStdMoveCheck.cpp
@@ -1,0 +1,47 @@
+//===--- ConstObjStdMoveCheck.cpp - clang-tidy ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ConstObjStdMoveCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+void ConstObjStdMoveCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      callExpr(
+          hasArgument(0, declRefExpr(hasType(qualType(isConstQualified())))))
+          .bind("const"),
+      this);
+}
+
+void ConstObjStdMoveCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<CallExpr>("const");
+  if (MatchedDecl->isCallToStdMove()) {
+    diag(MatchedDecl->getBeginLoc(),
+         "std::move should not be used on objects declared const or const &");
+  } else {
+    const FunctionDecl *FD = MatchedDecl->getDirectCallee();
+    const auto *NsDecl = cast<NamespaceDecl>(
+        FD->getDeclContext()->getEnclosingNamespaceContext());
+
+    if (FD->getIdentifier()->isStr("move") &&
+        NsDecl->getName().equals(StringRef("bsl"))) {
+      diag(MatchedDecl->getBeginLoc(),
+           "bsl::move should not be used on objects declared const or const &");
+    }
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/ConstObjStdMoveCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/ConstObjStdMoveCheck.h
@@ -1,0 +1,34 @@
+//===--- ConstObjStdMoveCheck.h - clang-tidy --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_CONSTOBJSTDMOVECHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_CONSTOBJSTDMOVECHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that std::move (and bsl::move) is not used on objects declared const or const&
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-const-obj-std-move.html
+class ConstObjStdMoveCheck : public ClangTidyCheck {
+public:
+  ConstObjStdMoveCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_CONSTOBJSTDMOVECHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -122,6 +122,11 @@ New checks
   Checks that copy and move constructors and copy assignment and move
   assignment operators are declared protected or deleted in base class.
 
+- New :doc:`bsl-const-obj-std-move
+  <clang-tidy/checks/bsl-const-obj-std-move>` check.
+
+  Warns if std::move (or bsl::move) is used on objects declared const or const&.
+
 - New :doc:`bsl-decl-forbidden
   <clang-tidy/checks/bsl-decl-forbidden>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-const-obj-std-move.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-const-obj-std-move.rst
@@ -1,0 +1,38 @@
+.. title:: clang-tidy - bsl-const-obj-std-move
+
+bsl-const-obj-std-move
+======================
+
+Warns if std::move (or bsl::move) is used on objects declared const or const&.
+
+Example:
+
+.. code-block:: c++
+
+  class A {
+  };
+
+  void f1() {
+    const A a1{};
+    A a2 = a1;            	// Compliant - copy constructor is called
+    A a3 = std::move(a1); 	// Non-compliant
+
+    A a4{};
+    A a5 = std::move(a4);	// Compliant
+
+    const A &a6{};
+    A a7 = std::move(a6);	// Non-compliant
+  }
+
+  void f2() {
+    const A a1{};
+    A a2 = a1;            	// Compliant - copy constructor is called
+    A a3 = bsl::move(a1); 	// Non-compliant
+
+    A a4{};
+    A a5 = bsl::move(a4);	// Compliant
+
+    const A &a6{};
+    A a7 = bsl::move(a6);	// Non-compliant
+  }
+

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -53,6 +53,7 @@ Clang-Tidy Checks
    `bsl-class-virtual-base <bsl-class-virtual-base.html>`_,
    `bsl-comparison-operators-forbidden <bsl-comparison-operators-forbidden.html>`_,
    `bsl-copy-move-access-specifier <bsl-copy-move-access-specifier.html>`_,
+   `bsl-const-obj-std-move <bsl-const-obj-std-move.html>`_, "Yes"
    `bsl-decl-forbidden <bsl-decl-forbidden.html>`_,
    `bsl-destructor-access-specifier <bsl-destructor-access-specifier.html>`_,
    `bsl-else-required-after-if <bsl-else-required-after-if.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-const-obj-std-move.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-const-obj-std-move.cpp
@@ -1,0 +1,102 @@
+// RUN: %check_clang_tidy %s bsl-const-obj-std-move %t
+
+// Manually define remove_reference
+template <class T> struct remove_reference { typedef T type; };
+
+template <class T> struct remove_reference<T &> { typedef T type; };
+
+template <class T> struct remove_reference<T &&> { typedef T type; };
+
+template <class T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+namespace std {
+// Manually define std::move
+template <typename T> constexpr remove_reference_t<T> &&move(T &&val) noexcept {
+  return static_cast<remove_reference_t<T> &&>(val);
+}
+} // namespace std
+
+namespace bsl {
+// Manually define bsl::move
+template <typename T> constexpr remove_reference_t<T> &&move(T &&val) noexcept {
+  return static_cast<remove_reference_t<T> &&>(val);
+}
+} // namespace bsl
+
+class A {};
+
+void f1() {
+  const A a1{};
+  A a2 = a1;            // Compliant - copy constructor is called
+  A a3 = std::move(a1); // Non-compliant
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: std::move should not be used on objects declared const or const & [bsl-const-obj-std-move]
+  A a4{};
+  A a5 = std::move(a4); // Compliant
+
+  const A &a6{};
+  A a7 = std::move(a6); // Non-compliant
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: std::move should not be used on objects declared const or const & [bsl-const-obj-std-move]
+}
+
+void f2() {
+  const A a1{};
+  A a2 = a1;            // Compliant - copy constructor is called
+  A a3 = bsl::move(a1); // Non-compliant
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: bsl::move should not be used on objects declared const or const & [bsl-const-obj-std-move]
+  A a4{};
+  A a5 = bsl::move(a4); // Compliant
+
+  const A &a6{};
+  A a7 = bsl::move(a6); // Non-compliant
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: bsl::move should not be used on objects declared const or const & [bsl-const-obj-std-move]
+}
+
+// Compliant; ignore other namespaces
+namespace foo {
+// Manually define foo::move
+template <typename T> constexpr remove_reference_t<T> &&move(T &&val) noexcept {
+  return static_cast<remove_reference_t<T> &&>(val);
+}
+} // namespace foo
+
+void f5() {
+  const A a1{};
+  A a2 = a1;
+  A a3 = foo::move(a1);
+  A a4{};
+  A a5 = foo::move(a4);
+
+  const A &a6{};
+  A a7 = foo::move(a6);
+}
+
+namespace other {
+A move(A a) { return A(); }
+} // namespace other
+
+void f3() {
+  const A a1{};
+  A a2 = a1;
+  A a3 = other::move(a1);
+
+  A a4{};
+  A a5 = other::move(a4);
+
+  const A &a6{};
+  A a7 = other::move(a6);
+}
+
+A move(A a) { return A(); }
+
+void f4() {
+  const A a1{};
+  A a2 = a1;
+  A a3 = move(a1);
+
+  A a4{};
+  A a5 = move(a4);
+
+  const A &a6{};
+  A a7 = move(a6);
+}


### PR DESCRIPTION
check_clang_tidy.py utility library include wip