### PR TITLE
[clang-tidy] Add bsl-for-loop-counter

### DIFF
--- a/clang-tools-extra/clang-tidy/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 add_subdirectory(android)
 add_subdirectory(abseil)
 add_subdirectory(bsl)
+add_subdirectory(bsltest)
 add_subdirectory(boost)
 add_subdirectory(bugprone)
 add_subdirectory(cert)
@@ -68,6 +69,7 @@ set(ALL_CLANG_TIDY_CHECKS
   clangTidyAndroidModule
   clangTidyAbseilModule
   clangTidyBslModule
+  clangTidyBslTestModule
   clangTidyBoostModule
   clangTidyBugproneModule
   clangTidyCERTModule

--- a/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
@@ -30,6 +30,11 @@ extern volatile int BslModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED BslModuleAnchorDestination =
     BslModuleAnchorSource;
 
+// This anchor is used to force the linker to link the BslTestModule.
+extern volatile int BslTestModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED BslTestModuleAnchorDestination =
+    BslTestModuleAnchorSource;
+
 // This anchor is used to force the linker to link the BoostModule.
 extern volatile int BoostModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED BoostModuleAnchorDestination =

--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -18,6 +18,7 @@
 #include "EnumExplicitCheck.h"
 #include "EnumInitCheck.h"
 #include "EnumScopedCheck.h"
+#include "ForLoopCounterCheck.h"
 #include "FriendDeclCheck.h"
 #include "FunctionNameUseCheck.h"
 #include "LambdaImplicitCaptureCheck.h"
@@ -73,6 +74,11 @@ public:
         "bsl-enum-init");
     CheckFactories.registerCheck<EnumScopedCheck>(
         "bsl-enum-scoped");
+<<<<<<< HEAD
+    CheckFactories.registerCheck<ForLoopCounterCheck>(
+        "bsl-for-loop-counter");
+=======
+>>>>>>> 6987314f3a8... Revert "For loop counter clang-tidy check"
     CheckFactories.registerCheck<FriendDeclCheck>(
         "bsl-friend-decl");
     CheckFactories.registerCheck<FunctionNameUseCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -12,6 +12,7 @@ add_clang_library(clangTidyBslModule
   EnumExplicitCheck.cpp
   EnumInitCheck.cpp
   EnumScopedCheck.cpp
+  ForLoopCounterCheck.cpp
   FriendDeclCheck.cpp
   FunctionNameUseCheck.cpp
   LambdaImplicitCaptureCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.cpp
@@ -1,0 +1,69 @@
+//===--- ForLoopCounterCheck.cpp - clang-tidy ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ForLoopCounterCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+void ForLoopCounterCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(expr(floatLiteral(), unless(hasParent(varDecl(hasInitializer(hasType(realFloatingPointType())))))).bind("floatlit"), this);
+
+  Finder->addMatcher(varDecl(hasType(realFloatingPointType())).bind("floatvar"), this);
+
+  Finder->addMatcher(forStmt(hasIncrement(binaryOperator(hasOperatorName(",")))).bind("singlecounter"), this);
+}
+
+void ForLoopCounterCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *ForIncSingle = Result.Nodes.getNodeAs<ForStmt>("singlecounter");
+  auto Mgr = Result.SourceManager;
+
+  if (ForIncSingle) {
+      auto LocS = ForIncSingle->getInc()->getExprLoc();
+      if (LocS.isInvalid() || LocS.isMacroID())
+        return;
+
+      if (Mgr->getFileID(LocS) != Mgr->getMainFileID())
+        return;
+
+      diag(LocS, "for loop must have single loop-counter");
+  }
+
+  const auto *FloatEx = Result.Nodes.getNodeAs<Expr>("floatlit");
+  if (FloatEx) {
+    auto LocF = FloatEx->getExprLoc();
+    if (LocF.isInvalid() || LocF.isMacroID())
+        return;
+
+    if (Mgr->getFileID(LocF) != Mgr->getMainFileID())
+      return;
+
+    diag(LocF, "float type not allowed (literal)");
+  }
+
+  const auto *FloatVar = Result.Nodes.getNodeAs<VarDecl>("floatvar");
+  if (FloatVar) {
+      auto LocFV = FloatVar->getBeginLoc();
+      if (LocFV.isInvalid() || LocFV.isMacroID())
+          return;
+
+      if (Mgr->getFileID(LocFV) != Mgr->getMainFileID())
+        return;
+
+      diag(LocFV, "float type not allowed (variable declaration)");
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.h
@@ -1,0 +1,38 @@
+//===--- ForLoopCounterCheck.h - clang-tidy ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that for loops use a single loop counter
+/// Checks that floating point types are not used
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-for-loop-counter.html
+class ForLoopCounterCheck : public ClangTidyCheck {
+public:
+  ForLoopCounterCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus11;
+  }
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H

--- a/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.h~HEAD
+++ b/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.h~HEAD
@@ -1,0 +1,38 @@
+//===--- ForLoopCounterCheck.h - clang-tidy ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that for loops use a single loop counter
+/// Checks that floating point types are not used
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-for-loop-counter.html
+class ForLoopCounterCheck : public ClangTidyCheck {
+public:
+  ForLoopCounterCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus11;
+  }
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H

--- a/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.h~d50bd26ab99... forloop check rename
+++ b/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.h~d50bd26ab99... forloop check rename
@@ -1,0 +1,38 @@
+//===--- ForLoopCounterCheck.h - clang-tidy ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that for loops use a single loop counter
+/// Checks that floating point types are not used
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-for-loop-counter.html
+class ForLoopCounterCheck : public ClangTidyCheck {
+public:
+  ForLoopCounterCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus11;
+  }
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H

--- a/clang-tools-extra/clang-tidy/bsltest/BslTestTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsltest/BslTestTidyModule.cpp
@@ -1,0 +1,38 @@
+//===------- BslTestTidyTestModule.cpp - clang-tidy -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../ClangTidy.h"
+#include "../ClangTidyModule.h"
+#include "../ClangTidyModuleRegistry.h"
+#include "ForLoopCheck.h"
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsltest {
+
+class BslTestModule : public ClangTidyModule {
+public:
+  void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<ForLoopCheck>(
+        "bsltest-for-loop");
+  }
+};
+
+// Register the BslTestModule using this statically initialized variable.
+static ClangTidyModuleRegistry::Add<BslTestModule> X("bsl-test-module",
+                                                   "Add additional bsl checks.");
+
+} // namespace bsltest
+
+// This anchor is used to force the linker to link in the generated object file
+// and thus register the BslTestModule.
+volatile int BslTestModuleAnchorSource = 0;
+
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsltest/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsltest/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_LINK_COMPONENTS support)
+
+add_clang_library(clangTidyBslTestModule
+  BslTestTidyModule.cpp
+  ForLoopCheck.cpp
+
+  LINK_LIBS
+  clangAST
+  clangASTMatchers
+  clangBasic
+  clangLex
+  clangTidy
+  clangTidyUtils
+  )

--- a/clang-tools-extra/clang-tidy/bsltest/ForLoopCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsltest/ForLoopCheck.cpp
@@ -1,0 +1,72 @@
+//===--- ForLoopCheck.cpp - clang-tidy ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ForLoopCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsltest {
+
+void ForLoopCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(expr(anyOf(floatLiteral(), expr(hasType(realFloatingPointType()))
+    )).bind("float"), this);
+
+  Finder->addMatcher(forStmt(hasIncrement(binaryOperator(hasOperatorName(",")))).bind("singlecounter"), this);
+
+  // Finder->addMatcher(forStmt(anyOf(
+  //   hasLoopInit(expr(binaryOperator(hasRHS(floatLiteral())))),
+  //   hasLoopInit(declStmt(hasSingleDecl(varDecl(hasType(realFloatingPointType()))))),
+  //   hasLoopInit(declStmt(hasSingleDecl(varDecl(hasDescendant(floatLiteral()))))) 
+  //   )).bind("floatinit"), this);
+  // Finder->addMatcher(forStmt(//anyOf(
+  //     // hasIncrement(expr(hasType(realFloatingPointType()))),
+  //     hasIncrement(binaryOperator(hasRHS(floatLiteral())))
+  //   ).bind("floatcounter"), this);
+  // Finder->addMatcher(forStmt(anyOf(
+  //     hasCondition(expr(hasType(realFloatingPointType()))),
+  //     hasCondition(binaryOperator(hasRHS(floatLiteral())))
+  //   )).bind("floatcond"), this);
+}
+
+void ForLoopCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *ForIncSingle = Result.Nodes.getNodeAs<ForStmt>("singlecounter");
+  if (ForIncSingle) {
+      auto locs = ForIncSingle->getInc()->getExprLoc();
+      diag(locs, "for loop must have single loop-counter");
+  }
+
+  const auto *FloatEx = Result.Nodes.getNodeAs<Expr>("float");
+  if (FloatEx) {
+      diag(FloatEx->getExprLoc(), "float type not allowed");
+  }
+
+  // const auto *ForInitFloat = Result.Nodes.getNodeAs<ForStmt>("floatinit");
+  // const auto *ForIncFloat = Result.Nodes.getNodeAs<ForStmt>("floatcounter");
+  // const auto *ForCondFloat = Result.Nodes.getNodeAs<ForStmt>("floatcond");
+  // SourceLocation locf; 
+
+  // if (ForInitFloat) {
+  //     locf = ForInitFloat->getInit()->getBeginLoc();
+  //     diag(locf, "for loop counter cannot be of floating point type");
+  // } else if (ForIncFloat) {
+  //     locf = ForIncFloat->getInc()->getExprLoc();
+  //     diag(locf, "for loop counter cannot be of floating point type (increment by float)");
+  // } else if (ForCondFloat) {
+  //     locf = ForCondFloat->getCond()->getExprLoc();
+  //     diag(locf, "for loop counter cannot be of floating point type (comparison to float)");
+  // }
+
+}
+
+} // namespace bsltest
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsltest/ForLoopCheck.h
+++ b/clang-tools-extra/clang-tidy/bsltest/ForLoopCheck.h
@@ -1,0 +1,38 @@
+//===--- ForLoopCheck.h - clang-tidy ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSLTEST_FORLOOPCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSLTEST_FORLOOPCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsltest {
+
+/// Checks that for loops use a single loop counter
+/// Checks that floating point types are not used
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsltest-for-loop.html
+class ForLoopCheck : public ClangTidyCheck {
+public:
+  ForLoopCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus11;
+  }
+};
+
+} // namespace bsltest
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSLTEST_FORLOOPCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -227,6 +227,11 @@ New checks
   non-auto-declared variables. Warns whenever any list initialization
   is used for auto-declared variables.
 
+- New :doc:`bsl-for-loop-counter
+  <clang-tidy/checks/bsl-for-loop-counter>` check.
+
+  Warns if for loop does not contain single loop-counter and uses floating point type.
+
 - New :doc:`cppcoreguidelines-avoid-non-const-global-variables
   <clang-tidy/checks/cppcoreguidelines-avoid-non-const-global-variables>` check.
   Finds non-const global variables as described in check I.2 of C++ Core

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-for-loop-counter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-for-loop-counter.rst
@@ -1,0 +1,18 @@
+.. title:: clang-tidy - bsl-for-loop-counter
+
+bsl-for-loop-counter-counter
+====================
+
+Checks that for loops contain a single loop-counter that is not of floating point type.
+
+Examples:
+
+.. code-block:: c++
+
+  constexpr float zlimit = 2.5F;
+  // Warning:
+  for (float z = 0.0F; z != zlimit; z += 0.1F) {}
+
+  // No warnings here:
+  constexpr std::int32_t ilimit = 100;
+  for (std::int32_t i = 0; i < ilimit; ++i) {}

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-for-loop-counter.rst~HEAD
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-for-loop-counter.rst~HEAD
@@ -1,0 +1,18 @@
+.. title:: clang-tidy - bsl-for-loop-counter
+
+bsl-for-loop-counter-counter
+====================
+
+Checks that for loops contain a single loop-counter that is not of floating point type.
+
+Examples:
+
+.. code-block:: c++
+
+  constexpr float zlimit = 2.5F;
+  // Warning:
+  for (float z = 0.0F; z != zlimit; z += 0.1F) {}
+
+  // No warnings here:
+  constexpr std::int32_t ilimit = 100;
+  for (std::int32_t i = 0; i < ilimit; ++i) {}

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-for-loop-counter.rst~d50bd26ab99... forloop check rename
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-for-loop-counter.rst~d50bd26ab99... forloop check rename
@@ -1,0 +1,18 @@
+.. title:: clang-tidy - bsl-for-loop-counter
+
+bsl-for-loop-counter-counter
+====================
+
+Checks that for loops contain a single loop-counter that is not of floating point type.
+
+Examples:
+
+.. code-block:: c++
+
+  constexpr float zlimit = 2.5F;
+  // Warning:
+  for (float z = 0.0F; z != zlimit; z += 0.1F) {}
+
+  // No warnings here:
+  constexpr std::int32_t ilimit = 100;
+  for (std::int32_t i = 0; i < ilimit; ++i) {}

--- a/clang-tools-extra/docs/clang-tidy/checks/bsltest-for-loop.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsltest-for-loop.rst
@@ -1,0 +1,18 @@
+.. title:: clang-tidy - bsltest-for-loop
+
+bsltest-for-loop
+================
+
+Checks that for loops contain a single loop-counter that is not of floating point type.
+
+Examples:
+
+.. code-block:: c++
+
+  constexpr float zlimit = 2.5F;
+  // Warning:
+  for (float z = 0.0F; z != zlimit; z += 0.1F) {}
+
+  // No warnings here:
+  constexpr std::int32_t ilimit = 100;
+  for (std::int32_t i = 0; i < ilimit; ++i) {}

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -54,6 +54,7 @@ Clang-Tidy Checks
    `bsl-enum-explicit <bsl-enum-explicit.html>`_,
    `bsl-enum-init <bsl-enum-init.html>`_,
    `bsl-enum-scoped <bsl-enum-scoped.html>`_,
+   `bsl-for-loop-counter <bsl-for-loop-counter.html>`_,
    `bsl-friend-decl <bsl-friend-decl.html>`_,
    `bsl-function-name-use <bsl-function-name-use.html>`_, "Yes"
    `bsl-lambda-implicit-capture <bsl-lambda-implicit-capture.html>`_,
@@ -82,6 +83,7 @@ Clang-Tidy Checks
    `bsl-unused-return-value <bsl-unused-return-value.html>`_,
    `bsl-using-decl-scope <bsl-using-decl-scope.html>`_,
    `bsl-var-braced-init <bsl-var-braced-init.html>`_,
+   `bsltest-for-loop <bsltest-for-loop.html>`_, "Yes"
    `bugprone-argument-comment <bugprone-argument-comment.html>`_, "Yes"
    `bugprone-assert-side-effect <bugprone-assert-side-effect.html>`_,
    `bugprone-bad-signal-to-kill-thread <bugprone-bad-signal-to-kill-thread.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-for-loop-counter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-for-loop-counter.cpp
@@ -1,0 +1,62 @@
+// RUN: %check_clang_tidy %s bsl-for-loop-counter %t
+
+// A6-5-2
+void foo()
+{
+	int y = 0;
+
+	long double l = 0;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	double d = 0;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	double d2 = 0.0;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	double d3;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	d3 = 0;
+
+	int f = 0.0;
+	// CHECK-MESSAGES: :[[@LINE-1]]:10: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (int i = 0; i < 3; ++i) {}
+
+	for (int x = 0; x < 3 && y < 15; x++, y++) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:38: warning: for loop must have single loop-counter [bsl-for-loop-counter]
+	
+	for (int x = 0, y = 0; x < 3 && y < 15; x++, y++) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:45: warning: for loop must have single loop-counter [bsl-for-loop-counter]
+
+	for (int x = 0, y = 0; x < 3; x++) {}
+
+	for (int x = 0; x < 3 && y < 15; x++) {}
+
+	for (float z = 0.0F; z < 1; z += 0.1F) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+	// CHECK-MESSAGES: :[[@LINE-2]]:35: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (float z = 0.0F; z < 3; z += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	float w;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	for (w = 0; w < 3; w += 1) {}
+
+	for (w = 0.0F; w < 3; w += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (int i = 0.0F; i < 3; i += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (int i = 0; i < 3; i += 0.1F) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:30: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (int i = 0; i < 3.0F; i++) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:22: warning: float type not allowed (literal) [bsl-for-loop-counter]
+}
+
+

--- a/clang-tools-extra/test/clang-tidy/checkers/bsltest-for-loop.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsltest-for-loop.cpp
@@ -1,0 +1,41 @@
+// RUN: %check_clang_tidy %s bsltest-for-loop %t
+#include <cstdint>
+
+// A6-5-2
+void foo()
+{
+	int y = 0;
+
+	for (int i = 0; i < 3; ++i) {}
+
+	for (int x = 0; x < 3 && y < 15; x++, y++) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:38: warning: For loop must have single loop-counter [bsltest-bitwise-type]
+	// CHECK-FIXES: {{^}}    for (int x = 0; x < 3 && y < 15; x++, y++) {}{{$}}
+
+	for (float z = 0.0F; z < 1; z += 0.1F) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: for loop counter cannot be of floating point type [bsltest-bitwise-type]
+	// CHECK-FIXES: {{^}}    for (float z = 0.0F; z < 1; z += 0.1F) {}{{$}}
+
+	for (float z = 0.0F; z < 3; z += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: for loop counter cannot be of floating point type [bsltest-bitwise-type]
+	// CHECK-FIXES: {{^}}    for (float z = 0.0F; z < 3; z += 1) {}{{$}}
+
+	float w;
+	for (w = 0.0F; w < 3; w += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: for loop counter cannot be of floating point type [bsltest-bitwise-type]
+	// CHECK-FIXES: {{^}}    for (w = 0.0F; w < 3; w += 1) {}{{$}}
+
+	for (int i = 0.0F; i < 3; i += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: for loop counter cannot be of floating point type [bsltest-bitwise-type]
+	// CHECK-FIXES: {{^}}    for (int i = 0.0F; i < 3; i += 1)  {}{{$}}
+
+	for (int i = 0; i < 3; i += 0.1F) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:27: warning: for loop counter cannot be of floating point type (increment by float) [bsltest-bitwise-type]
+	// CHECK-FIXES: {{^}}    for (int i = 0; i < 3; i += 0.1F) {}{{$}}
+
+	for (int i = 0; i < 3.0F; i++) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:20: warning: for loop counter cannot be of floating point type (comparison to float) [bsltest-bitwise-type]
+	// CHECK-FIXES: {{^}}    for (int i = 0; i < 3.0F; i++) {}{{$}}
+}
+
+


### PR DESCRIPTION
A6-5-2
Checks that for loops use a single loop counter
Checks that floating point types are not used