### PR TITLE
[clang-tidy] Add bsl-for-loop-counter

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -18,6 +18,7 @@
 #include "EnumExplicitCheck.h"
 #include "EnumInitCheck.h"
 #include "EnumScopedCheck.h"
+#include "ForLoopCounterCheck.h"
 #include "FriendDeclCheck.h"
 #include "FunctionNameUseCheck.h"
 #include "LambdaImplicitCaptureCheck.h"
@@ -73,6 +74,8 @@ public:
         "bsl-enum-init");
     CheckFactories.registerCheck<EnumScopedCheck>(
         "bsl-enum-scoped");
+    CheckFactories.registerCheck<ForLoopCounterCheck>(
+        "bsl-for-loop-counter");
     CheckFactories.registerCheck<FriendDeclCheck>(
         "bsl-friend-decl");
     CheckFactories.registerCheck<FunctionNameUseCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -12,6 +12,7 @@ add_clang_library(clangTidyBslModule
   EnumExplicitCheck.cpp
   EnumInitCheck.cpp
   EnumScopedCheck.cpp
+  ForLoopCounterCheck.cpp
   FriendDeclCheck.cpp
   FunctionNameUseCheck.cpp
   LambdaImplicitCaptureCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.cpp
@@ -1,0 +1,69 @@
+//===--- ForLoopCounterCheck.cpp - clang-tidy ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ForLoopCounterCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+void ForLoopCounterCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(expr(floatLiteral(), unless(hasParent(varDecl(hasInitializer(hasType(realFloatingPointType())))))).bind("floatlit"), this);
+
+  Finder->addMatcher(varDecl(hasType(realFloatingPointType())).bind("floatvar"), this);
+
+  Finder->addMatcher(forStmt(hasIncrement(binaryOperator(hasOperatorName(",")))).bind("singlecounter"), this);
+}
+
+void ForLoopCounterCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *ForIncSingle = Result.Nodes.getNodeAs<ForStmt>("singlecounter");
+  auto Mgr = Result.SourceManager;
+
+  if (ForIncSingle) {
+      auto LocS = ForIncSingle->getInc()->getExprLoc();
+      if (LocS.isInvalid() || LocS.isMacroID())
+        return;
+
+      if (Mgr->getFileID(LocS) != Mgr->getMainFileID())
+        return;
+
+      diag(LocS, "for loop must have single loop-counter");
+  }
+
+  const auto *FloatEx = Result.Nodes.getNodeAs<Expr>("floatlit");
+  if (FloatEx) {
+    auto LocF = FloatEx->getExprLoc();
+    if (LocF.isInvalid() || LocF.isMacroID())
+        return;
+
+    if (Mgr->getFileID(LocF) != Mgr->getMainFileID())
+      return;
+
+    diag(LocF, "float type not allowed (literal)");
+  }
+
+  const auto *FloatVar = Result.Nodes.getNodeAs<VarDecl>("floatvar");
+  if (FloatVar) {
+      auto LocFV = FloatVar->getBeginLoc();
+      if (LocFV.isInvalid() || LocFV.isMacroID())
+          return;
+
+      if (Mgr->getFileID(LocFV) != Mgr->getMainFileID())
+        return;
+
+      diag(LocFV, "float type not allowed (variable declaration)");
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.h
@@ -1,0 +1,38 @@
+//===--- ForLoopCounterCheck.h - clang-tidy ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that for loops use a single loop counter
+/// Checks that floating point types are not used
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-for-loop-counter.html
+class ForLoopCounterCheck : public ClangTidyCheck {
+public:
+  ForLoopCounterCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus11;
+  }
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORLOOPCOUNTERCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -227,6 +227,11 @@ New checks
   non-auto-declared variables. Warns whenever any list initialization
   is used for auto-declared variables.
 
+- New :doc:`bsl-for-loop-counter
+  <clang-tidy/checks/bsl-for-loop-counter>` check.
+
+  Warns if for loop does not contain single loop-counter and uses floating point type.
+
 - New :doc:`cppcoreguidelines-avoid-non-const-global-variables
   <clang-tidy/checks/cppcoreguidelines-avoid-non-const-global-variables>` check.
   Finds non-const global variables as described in check I.2 of C++ Core

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-for-loop-counter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-for-loop-counter.rst
@@ -1,0 +1,18 @@
+.. title:: clang-tidy - bsl-for-loop-counter
+
+bsl-for-loop-counter-counter
+====================
+
+Checks that for loops contain a single loop-counter that is not of floating point type.
+
+Examples:
+
+.. code-block:: c++
+
+  constexpr float zlimit = 2.5F;
+  // Warning:
+  for (float z = 0.0F; z != zlimit; z += 0.1F) {}
+
+  // No warnings here:
+  constexpr std::int32_t ilimit = 100;
+  for (std::int32_t i = 0; i < ilimit; ++i) {}

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -54,6 +54,7 @@ Clang-Tidy Checks
    `bsl-enum-explicit <bsl-enum-explicit.html>`_,
    `bsl-enum-init <bsl-enum-init.html>`_,
    `bsl-enum-scoped <bsl-enum-scoped.html>`_,
+   `bsl-for-loop-counter <bsl-for-loop-counter.html>`_,
    `bsl-friend-decl <bsl-friend-decl.html>`_,
    `bsl-function-name-use <bsl-function-name-use.html>`_, "Yes"
    `bsl-lambda-implicit-capture <bsl-lambda-implicit-capture.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-for-loop-counter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-for-loop-counter.cpp
@@ -1,0 +1,62 @@
+// RUN: %check_clang_tidy %s bsl-for-loop-counter %t
+
+// A6-5-2
+void foo()
+{
+	int y = 0;
+
+	long double l = 0;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	double d = 0;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	double d2 = 0.0;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	double d3;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	d3 = 0;
+
+	int f = 0.0;
+	// CHECK-MESSAGES: :[[@LINE-1]]:10: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (int i = 0; i < 3; ++i) {}
+
+	for (int x = 0; x < 3 && y < 15; x++, y++) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:38: warning: for loop must have single loop-counter [bsl-for-loop-counter]
+	
+	for (int x = 0, y = 0; x < 3 && y < 15; x++, y++) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:45: warning: for loop must have single loop-counter [bsl-for-loop-counter]
+
+	for (int x = 0, y = 0; x < 3; x++) {}
+
+	for (int x = 0; x < 3 && y < 15; x++) {}
+
+	for (float z = 0.0F; z < 1; z += 0.1F) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+	// CHECK-MESSAGES: :[[@LINE-2]]:35: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (float z = 0.0F; z < 3; z += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	float w;
+	// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: float type not allowed (variable declaration) [bsl-for-loop-counter]
+
+	for (w = 0; w < 3; w += 1) {}
+
+	for (w = 0.0F; w < 3; w += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (int i = 0.0F; i < 3; i += 1) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (int i = 0; i < 3; i += 0.1F) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:30: warning: float type not allowed (literal) [bsl-for-loop-counter]
+
+	for (int i = 0; i < 3.0F; i++) {}
+	// CHECK-MESSAGES: :[[@LINE-1]]:22: warning: float type not allowed (literal) [bsl-for-loop-counter]
+}
+
+


### PR DESCRIPTION
A6-5-2
Checks that for loops use a single loop counter
Checks that floating point types are not used