### PR TITLE
[clang-tidy] Add bsl-destructor-access-specifier

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -15,6 +15,7 @@
 #include "ClassMemberRedefinedCheck.h"
 #include "ClassVirtualBaseCheck.h"
 #include "DeclForbiddenCheck.h"
+#include "DestructorAccessSpecifierCheck.h"
 #include "EnumExplicitCheck.h"
 #include "EnumInitCheck.h"
 #include "EnumScopedCheck.h"
@@ -67,6 +68,8 @@ public:
         "bsl-class-virtual-base");
     CheckFactories.registerCheck<DeclForbiddenCheck>(
         "bsl-decl-forbidden");
+    CheckFactories.registerCheck<DestructorAccessSpecifierCheck>(
+        "bsl-destructor-access-specifier");
     CheckFactories.registerCheck<EnumExplicitCheck>(
         "bsl-enum-explicit");
     CheckFactories.registerCheck<EnumInitCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -9,6 +9,7 @@ add_clang_library(clangTidyBslModule
   ClassMemberRedefinedCheck.cpp
   ClassVirtualBaseCheck.cpp
   DeclForbiddenCheck.cpp
+  DestructorAccessSpecifierCheck.cpp
   EnumExplicitCheck.cpp
   EnumInitCheck.cpp
   EnumScopedCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.cpp
@@ -1,0 +1,57 @@
+//===--- DestructorAccessSpecifierCheck.cpp - clang-tidy ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DestructorAccessSpecifierCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+AST_MATCHER(CXXDestructorDecl, isPublicVirtual) {
+  return Node.getAccess() == AS_public && Node.isVirtual();
+}
+
+AST_MATCHER(CXXDestructorDecl, isProtectedNonVirtual) {
+  return Node.getAccess() == AS_protected && !Node.isVirtual();
+}
+
+void DestructorAccessSpecifierCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(cxxDestructorDecl(unless(anyOf(isPublicVirtual(),
+                                                    isProtectedNonVirtual())))
+                         .bind("destructor"),
+                     this);
+}
+
+void DestructorAccessSpecifierCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  const auto Mgr = Result.SourceManager;
+
+  const auto *MatchedDecl =
+      Result.Nodes.getNodeAs<CXXDestructorDecl>("destructor");
+  if (MatchedDecl) {
+    auto Loc = MatchedDecl->getLocation();
+    if (Mgr->getFileID(Loc) != Mgr->getMainFileID())
+      return;
+
+    if (MatchedDecl->getAccess() == AS_public &&
+        MatchedDecl->getParent()->isEffectivelyFinal())
+      return;
+
+    diag(Loc, "base class destructor must be public virtual, public override, "
+              "or protected non-virtual. If public destructor is nonvirtual, "
+              "then class must be declared final.");
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.h
@@ -1,0 +1,36 @@
+//===--- DestructorAccessSpecifierCheck.h - clang-tidy ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_DESTRUCTORACCESSSPECIFIERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_DESTRUCTORACCESSSPECIFIERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Check that destructor base class is public virtual, public override, or
+/// protected non-virtual. If public destructor has non-virtual class, then
+/// declare class as final
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-destructor-access-specifier.html
+class DestructorAccessSpecifierCheck : public ClangTidyCheck {
+public:
+  DestructorAccessSpecifierCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_DESTRUCTORACCESSSPECIFIERCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -111,6 +111,12 @@ New checks
 
   Warns if unions or bitfields are declared.
 
+- New :doc:`bsl-destructor-access-specifier
+  <clang-tidy/checks/bsl-destructor-access-specifier>` check.
+
+  Warns if destructor of base class is not public virtual, public override, 
+  or protected non-virtual, unless public destructor is non-virtual in final class.
+
 - New :doc:`bsl-friend-decl
   <clang-tidy/checks/bsl-friend-decl>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-destructor-access-specifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-destructor-access-specifier.rst
@@ -1,0 +1,85 @@
+.. title:: clang-tidy - bsl-destructor-access-specifier
+
+bsl-destructor-access-specifier
+===============================
+
+Warns if destructor of base class is not public virtual, public override, 
+or protected non-virtual, unless public destructor is non-virtual in final class.
+
+Example:
+
+.. code-block:: c++
+
+class A {	// Warning
+public:
+  ~A(){}
+};
+
+class B : public A {};	// Warning
+
+class C {	// No warning
+public:
+  virtual ~C()
+  {}
+};
+
+class D : public C {};
+
+class E { 	// No warning
+protected:
+  ~E();
+};
+
+class F 	// Warning
+{
+public:
+  ~F() = default;
+};
+
+class G final	// No warning
+{
+public:
+  ~G() = default;
+};
+
+class H		// Warning
+{
+public:
+  virtual ~H() = default;
+};
+
+class I : public F {};	// Warning
+
+class J : public H {};
+
+class K : H 	// No warning
+{
+public:
+  ~K() override = default;
+};
+
+class L : H 	// Warning
+{
+private:
+  ~L() override = default;
+};
+
+
+template <typename T> class X { // Non-compliant
+private:
+  T t;
+
+public:		// Warning
+  T get_t() { return t; }
+  ~X() = default;
+};
+
+template <typename T> class Y final {	// No warning
+public:
+  ~Y() = default; 
+};
+
+template <typename T> class Z {		// No warning
+public:
+  virtual ~Z() = default; 
+};

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -51,6 +51,7 @@ Clang-Tidy Checks
    `bsl-class-member-redefined <bsl-class-member-redefined.html>`_,
    `bsl-class-virtual-base <bsl-class-virtual-base.html>`_,
    `bsl-decl-forbidden <bsl-decl-forbidden.html>`_,
+   `bsl-destructor-access-specifier <bsl-destructor-access-specifier.html>`_, "Yes"
    `bsl-enum-explicit <bsl-enum-explicit.html>`_,
    `bsl-enum-init <bsl-enum-init.html>`_,
    `bsl-enum-scoped <bsl-enum-scoped.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
@@ -1,0 +1,82 @@
+// RUN: %check_clang_tidy %s bsl-destructor-access-specifier %t
+
+class A { // Non-compliant
+public:
+  ~A()
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+  {}
+};
+
+class B : public A {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+
+class C { // Compliant
+public:
+  virtual ~C()
+  {}
+};
+
+class D : public C {};
+
+class E { // Compliant
+protected:
+  ~E();
+};
+
+class F // Non-compliant
+{
+public:
+  ~F() = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+};
+
+class G final // Compliant
+{
+public:
+  ~G() = default;
+};
+
+class H // Compliant
+{
+public:
+  virtual ~H() = default;
+};
+
+class I : public F {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+
+class J : public H {};
+
+class K : H // compliant
+{
+public:
+  ~K() override = default;
+};
+
+class L : H // Non-compliant
+{
+private:
+  ~L() override = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+};
+
+
+template <typename T> class X { // Non-compliant
+private:
+  T t;
+
+public:
+  T get_t() { return t; }
+  ~X() = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: base class destructor must be public virtual, public override, or protected non-virtual. If public destructor is nonvirtual, then class must be declared final. [bsl-destructor-access-specifier]
+};
+
+template <typename T> class Y final {
+public:
+  ~Y() = default; 
+};
+
+template <typename T> class Z {
+public:
+  virtual ~Z() = default; 
+};


### PR DESCRIPTION
Destructor of a base class shall be public virtual, public override or protected non-virtual. If a public destructor of a class is non-virtual, then the class should be declared final.