### PR TITLE
[clang-tidy] Add bsl-identifier-typographically-unambiguous

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -20,6 +20,7 @@
 #include "EnumScopedCheck.h"
 #include "FriendDeclCheck.h"
 #include "FunctionNameUseCheck.h"
+#include "IdentifierTypographicallyUnambiguousCheck.h"
 #include "LambdaImplicitCaptureCheck.h"
 #include "LambdaParamListCheck.h"
 #include "LiteralsAsciiOnlyCheck.h"
@@ -77,6 +78,8 @@ public:
         "bsl-friend-decl");
     CheckFactories.registerCheck<FunctionNameUseCheck>(
         "bsl-function-name-use");
+    CheckFactories.registerCheck<IdentifierTypographicallyUnambiguousCheck>(
+        "bsl-identifier-typographically-unambiguous");
     CheckFactories.registerCheck<LambdaImplicitCaptureCheck>(
         "bsl-lambda-implicit-capture");
     CheckFactories.registerCheck<LambdaParamListCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_library(clangTidyBslModule
   EnumScopedCheck.cpp
   FriendDeclCheck.cpp
   FunctionNameUseCheck.cpp
+  IdentifierTypographicallyUnambiguousCheck.cpp
   LambdaImplicitCaptureCheck.cpp
   LambdaParamListCheck.cpp
   LiteralsAsciiOnlyCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/IdentifierTypographicallyUnambiguousCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/IdentifierTypographicallyUnambiguousCheck.cpp
@@ -1,0 +1,92 @@
+//===--- IdentifierTypographicallyUnambiguousCheck.cpp - clang-tidy -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "IdentifierTypographicallyUnambiguousCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+struct map_entry {
+  std::string og_name;
+  SourceLocation loc;
+};
+
+std::unordered_map<std::string, map_entry> idNames;
+
+void IdentifierTypographicallyUnambiguousCheck::registerMatchers(
+    MatchFinder *Finder) {
+  Finder->addMatcher(namedDecl().bind("id"), this);
+}
+
+void IdentifierTypographicallyUnambiguousCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<NamedDecl>("id");
+  auto Mgr = Result.SourceManager;
+
+  if (MatchedDecl) {
+    auto Loc = MatchedDecl->getLocation();
+    if (Mgr->getFileID(Loc) != Mgr->getMainFileID())
+      return;
+
+    std::string og_name = MatchedDecl->getNameAsString();
+    std::string name = MatchedDecl->getName().lower();
+
+    unsigned int i = 0;
+
+    while (i < name.length()) {
+      if (name[i] == '_') {
+        name.erase(i, 1);
+      } else {
+        if (name[i] == '0') {
+          name.replace(i, 1, "o");
+        } else if (name[i] == '1') {
+          name.replace(i, 1, "i");
+        } else if (name[i] == 'l') {
+          name.replace(i, 1, "i");
+        } else if (name[i] == '5') {
+          name.replace(i, 1, "s");
+        } else if (name[i] == '2') {
+          name.replace(i, 1, "z");
+        } else if (name[i] == 'h') {
+          name.replace(i, 1, "n");
+        } else if (name[i] == '8') {
+          name.replace(i, 1, "b");
+        } else if (name[i] == 'r' && i < name.length() - 1 &&
+                   name[i + 1] == 'n') {
+          name.replace(i, 2, "m");
+        }
+        i += 1;
+      }
+    }
+
+    std::unordered_map<std::string, map_entry>::iterator itr =
+        idNames.find(name);
+    if (itr != idNames.end()) {
+      map_entry m = itr->second;
+      std::string og_name = m.og_name;
+      unsigned int locnum = Mgr->getPresumedLoc(m.loc).getLine();
+      diag(Loc, "Identifier typographically ambiguous with identifier '%0' on "
+                "line %1")
+          << og_name << locnum;
+    } else {
+      idNames[name] = map_entry{og_name, Loc};
+    }
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/IdentifierTypographicallyUnambiguousCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/IdentifierTypographicallyUnambiguousCheck.h
@@ -1,0 +1,34 @@
+//===--- IdentifierTypographicallyUnambiguousCheck.h - clang-tidy *- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_IDENTIFIERTYPOGRAPHICALLYUNAMBIGUOUSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_IDENTIFIERTYPOGRAPHICALLYUNAMBIGUOUSCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that different identifiers are typographically unambiguous
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-identifier-typographically-unambiguous.html
+class IdentifierTypographicallyUnambiguousCheck : public ClangTidyCheck {
+public:
+  IdentifierTypographicallyUnambiguousCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_IDENTIFIERTYPOGRAPHICALLYUNAMBIGUOUSCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -122,6 +122,11 @@ New checks
   Warns if a function name is used in an expression other than a call
   or address-of.
 
+- New :doc:`bsl-identifier-typographically-unambiguous
+  <clang-tidy/checks/bsl-identifier-typographically-unambiguous>` check.
+
+  Checks that different identifiers are typographically unambiguous.
+
 - New :doc:`bsl-lambda-implicit-capture
   <clang-tidy/checks/bsl-lambda-implicit-capture>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-identifier-typographically-unambiguous.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-identifier-typographically-unambiguous.rst
@@ -1,0 +1,46 @@
+.. title:: clang-tidy - bsl-identifier-typographically-unambiguous
+
+bsl-identifier-typographically-unambiguous
+==========================================
+
+Checks that different identifiers are typographically unambiguous
+
+Examples:
+
+.. code-block:: c++
+
+int id1_a_b_c;
+int id1_abc; // Warning
+
+int id2_abc;
+int id2_ABC; // Warning
+
+int id3_a_bc;
+int id3_ab_c; // Warning
+
+int id4_a_bc;
+int id4_ab_c; // Warning
+
+int id5_ii;
+int id5_11; // Warning
+
+int id6_i0;
+int id6_1O; // Warning
+
+int id7_in;
+int id7_1h; // Warning
+
+int id8_Z5;
+int id8_2S; // Warning
+
+int id9_ZS;
+int id9_25; // Warning
+
+void frn0();
+void frno(); // Warning
+
+void frn();
+void fm(); // Warning
+void f___m(); // Warning
+
+

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -56,6 +56,7 @@ Clang-Tidy Checks
    `bsl-enum-scoped <bsl-enum-scoped.html>`_,
    `bsl-friend-decl <bsl-friend-decl.html>`_,
    `bsl-function-name-use <bsl-function-name-use.html>`_, "Yes"
+   `bsl-identifier-typographically-unambiguous <bsl-identifier-typographically-unambiguous.html>`_, "Yes"
    `bsl-lambda-implicit-capture <bsl-lambda-implicit-capture.html>`_,
    `bsl-lambda-param-list <bsl-lambda-param-list.html>`_,
    `bsl-literals-ascii-only <bsl-literals-ascii-only.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-identifier-typographically-unambiguous.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-identifier-typographically-unambiguous.cpp
@@ -1,0 +1,47 @@
+// RUN: %check_clang_tidy %s bsl-identifier-typographically-unambiguous %t
+
+int id1_a_b_c;
+int id1_abc; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id1_a_b_c' on line 3 [bsl-identifier-typographically-unambiguous]
+
+int id2_abc;
+int id2_ABC; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id2_abc' on line 7 [bsl-identifier-typographically-unambiguous]
+
+int id3_a_bc;
+int id3_ab_c; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id3_a_bc' on line 11 [bsl-identifier-typographically-unambiguous]
+
+int id4_a_bc;
+int id4_ab_c; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id4_a_bc' on line 15 [bsl-identifier-typographically-unambiguous]
+
+int id5_ii;
+int id5_11; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id5_ii' on line 19 [bsl-identifier-typographically-unambiguous]
+
+int id6_i0;
+int id6_1O; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id6_i0' on line 23 [bsl-identifier-typographically-unambiguous]
+
+int id7_in;
+int id7_1h; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id7_in' on line 27 [bsl-identifier-typographically-unambiguous]
+
+int id8_Z5;
+int id8_2S; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id8_Z5' on line 31 [bsl-identifier-typographically-unambiguous]
+
+int id9_ZS;
+int id9_25; // Non-compliant
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Identifier typographically ambiguous with identifier 'id9_ZS' on line 35 [bsl-identifier-typographically-unambiguous]
+
+void frn0();
+void frno();
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Identifier typographically ambiguous with identifier 'frn0' on line 39 [bsl-identifier-typographically-unambiguous]
+
+void frn();
+void fm();
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Identifier typographically ambiguous with identifier 'frn' on line 43 [bsl-identifier-typographically-unambiguous] 
+void f___m();
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Identifier typographically ambiguous with identifier 'frn' on line 43 [bsl-identifier-typographically-unambiguous]


### PR DESCRIPTION
M2-10-1
Different identifiers shall be typographically unambiguous.