### PR TITLE
Hotfix

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/DestructorAccessSpecifierCheck.cpp
@@ -33,18 +33,16 @@ void DestructorAccessSpecifierCheck::registerMatchers(MatchFinder *Finder) {
 
 void DestructorAccessSpecifierCheck::check(
     const MatchFinder::MatchResult &Result) {
-  const auto Mgr = Result.SourceManager;
-
   const auto *MatchedDecl =
       Result.Nodes.getNodeAs<CXXDestructorDecl>("destructor");
   if (MatchedDecl) {
     auto Loc = MatchedDecl->getLocation();
-    if (Mgr->getFileID(Loc) != Mgr->getMainFileID())
-      return;
 
-    if (MatchedDecl->getAccess() == AS_public &&
-        MatchedDecl->getParent()->isEffectivelyFinal())
+    const auto Parent = MatchedDecl->getParent();
+    if (Parent->isLambda() || (MatchedDecl->getAccess() == AS_public &&
+                               Parent->isEffectivelyFinal())) {
       return;
+    }
 
     diag(Loc, "base class destructor must be public virtual, public override, "
               "or protected non-virtual. If public destructor is nonvirtual, "

--- a/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/ForLoopCounterCheck.cpp
@@ -26,14 +26,10 @@ void ForLoopCounterCheck::registerMatchers(MatchFinder *Finder) {
 
 void ForLoopCounterCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *ForIncSingle = Result.Nodes.getNodeAs<ForStmt>("singlecounter");
-  auto Mgr = Result.SourceManager;
 
   if (ForIncSingle) {
       auto LocS = ForIncSingle->getInc()->getExprLoc();
       if (LocS.isInvalid() || LocS.isMacroID())
-        return;
-
-      if (Mgr->getFileID(LocS) != Mgr->getMainFileID())
         return;
 
       diag(LocS, "for loop must have single loop-counter");
@@ -45,9 +41,6 @@ void ForLoopCounterCheck::check(const MatchFinder::MatchResult &Result) {
     if (LocF.isInvalid() || LocF.isMacroID())
         return;
 
-    if (Mgr->getFileID(LocF) != Mgr->getMainFileID())
-      return;
-
     diag(LocF, "float type not allowed (literal)");
   }
 
@@ -56,9 +49,6 @@ void ForLoopCounterCheck::check(const MatchFinder::MatchResult &Result) {
       auto LocFV = FloatVar->getBeginLoc();
       if (LocFV.isInvalid() || LocFV.isMacroID())
           return;
-
-      if (Mgr->getFileID(LocFV) != Mgr->getMainFileID())
-        return;
 
       diag(LocFV, "float type not allowed (variable declaration)");
   }

--- a/clang-tools-extra/clang-tidy/bsl/IdentifierTypographicallyUnambiguousCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/IdentifierTypographicallyUnambiguousCheck.cpp
@@ -28,18 +28,16 @@ std::unordered_map<std::string, map_entry> idNames;
 
 void IdentifierTypographicallyUnambiguousCheck::registerMatchers(
     MatchFinder *Finder) {
-  Finder->addMatcher(namedDecl().bind("id"), this);
+  Finder->addMatcher(declaratorDecl().bind("id"), this);
 }
 
 void IdentifierTypographicallyUnambiguousCheck::check(
     const MatchFinder::MatchResult &Result) {
-  const auto *MatchedDecl = Result.Nodes.getNodeAs<NamedDecl>("id");
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<DeclaratorDecl>("id");
   auto Mgr = Result.SourceManager;
 
   if (MatchedDecl) {
     auto Loc = MatchedDecl->getLocation();
-    if (Mgr->getFileID(Loc) != Mgr->getMainFileID())
-      return;
 
     std::string og_name = MatchedDecl->getNameAsString();
     std::string name = MatchedDecl->getName().lower();

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-destructor-access-specifier.cpp
@@ -80,3 +80,5 @@ template <typename T> class Z {
 public:
   virtual ~Z() = default; 
 };
+
+auto test = []{ return 3; };

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-identifier-typographically-unambiguous.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-identifier-typographically-unambiguous.cpp
@@ -45,3 +45,7 @@ void fm();
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Identifier typographically ambiguous with identifier 'frn' on line 43 [bsl-identifier-typographically-unambiguous] 
 void f___m();
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Identifier typographically ambiguous with identifier 'frn' on line 43 [bsl-identifier-typographically-unambiguous]
+
+template<typename FUNC>
+void
+example(FUNC &&f, const int name);

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-non-pod-classdef.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-non-pod-classdef.cpp
@@ -7,16 +7,17 @@ class NonPod {
 };
 
 class Trivial {
-// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: non-POD class types should have private member data [bsl-non-pod-classdef]
 public:
   int a;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: non-POD class types should have private member data [bsl-non-pod-classdef]
+  static constexpr int x = 10;
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: non-POD class types should have private member data [bsl-non-pod-classdef]
 
 private:
   int b;
 };
 
 class StandardL {
-// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: non-POD class types should have private member data [bsl-non-pod-classdef]
   int a;
   int b;
 
@@ -30,10 +31,20 @@ class Pod {
 };
 
 struct NonPodStruct {
-// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: non-POD type should be defined as a class [bsl-non-pod-classdef]
+  // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: non-POD type should be defined as a class [bsl-non-pod-classdef]
 public:
   int a;
 
 private:
   int b;
+};
+
+class test final {
+  bool var{};
+
+private:
+  static constexpr int x = 10;
+
+public:
+  static void func(int i, const int x) {}
 };


### PR DESCRIPTION
Remove FileID
bsl-fix-destructor-access-specifier: Ignore lambda destructor
bsl-fix-non-pod-classdef: Remove match on public member functions, match on var
bsl-fix-identifier-typographically-unambiguous: Use declaratorDecl