### PR TITLE
[clang-tidy] Add bsl-template-generic-param

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -53,8 +53,9 @@
 #include "StmtSwitchCaseParentCheck.h"
 #include "StmtSwitchDefaultBreakCheck.h"
 #include "StmtSwitchDefaultLastCheck.h"
-#include "TernaryOperatorForbiddenCheck.h"
 #include "StructDefCheck.h"
+#include "TemplateGenericParamCheck.h"
+#include "TernaryOperatorForbiddenCheck.h"
 #include "TypesFixedWidthIntsCheck.h"
 #include "TypesNoWideCharCheck.h"
 #include "UnusedReturnValueCheck.h"
@@ -150,10 +151,12 @@ public:
         "bsl-stmt-switch-default-break");
     CheckFactories.registerCheck<StmtSwitchDefaultLastCheck>(
         "bsl-stmt-switch-default-last");
-    CheckFactories.registerCheck<TernaryOperatorForbiddenCheck>(
-        "bsl-ternary-operator-forbidden");
     CheckFactories.registerCheck<StructDefCheck>(
         "bsl-struct-def");
+    CheckFactories.registerCheck<TemplateGenericParamCheck>(
+        "bsl-template-generic-param");
+    CheckFactories.registerCheck<TernaryOperatorForbiddenCheck>(
+        "bsl-ternary-operator-forbidden");
     CheckFactories.registerCheck<TypesFixedWidthIntsCheck>(
         "bsl-types-fixed-width-ints");
     CheckFactories.registerCheck<LiteralsAsciiOnlyCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -47,8 +47,9 @@ add_clang_library(clangTidyBslModule
   StmtSwitchCaseParentCheck.cpp
   StmtSwitchDefaultBreakCheck.cpp
   StmtSwitchDefaultLastCheck.cpp
-  TernaryOperatorForbiddenCheck.cpp
   StructDefCheck.cpp
+  TemplateGenericParamCheck.cpp
+  TernaryOperatorForbiddenCheck.cpp
   TypesFixedWidthIntsCheck.cpp
   TypesNoWideCharCheck.cpp
   UnusedReturnValueCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/TemplateGenericParamCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/TemplateGenericParamCheck.cpp
@@ -1,0 +1,100 @@
+//===--- TemplateGenericParamCheck.cpp - clang-tidy -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TemplateGenericParamCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/AST/TemplateName.h"
+#include <iostream>
+
+using namespace clang::ast_matchers;
+using namespace std;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+AST_MATCHER(CXXMethodDecl, isConstructor) {
+  return isa<CXXConstructorDecl>(Node);
+}
+
+void TemplateGenericParamCheck::registerMatchers(MatchFinder *Finder) {
+  auto ForwardingRefParm =
+      anyOf(parmVarDecl(
+          hasType(templateTypeParmType(hasDeclaration(
+                               templateTypeParmDecl().bind("type-parm-decl"))))) 
+          .bind("parm-var"),
+          parmVarDecl(
+          hasType(qualType(references(templateTypeParmType(hasDeclaration(
+                               templateTypeParmDecl().bind("type-parm-decl"))))
+                                )))
+          .bind("parm-var"));
+
+  DeclarationMatcher findOverload =
+      cxxConstructorDecl(
+          hasParameter(0, ForwardingRefParm))
+          .bind("ctor");
+  Finder->addMatcher(findOverload, this);
+
+  DeclarationMatcher findOpOverload =
+      cxxMethodDecl(
+          hasParameter(0, ForwardingRefParm), unless(isConstructor()))
+          .bind("copy-assign");
+  Finder->addMatcher(findOpOverload, this);
+}
+
+void TemplateGenericParamCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *ParmVar = Result.Nodes.getNodeAs<ParmVarDecl>("parm-var");
+  const auto *TypeParmDecl =
+      Result.Nodes.getNodeAs<TemplateTypeParmDecl>("type-parm-decl");
+
+  // Get the FunctionDecl and FunctionTemplateDecl containing the function
+  // parameter.
+  const auto *FuncForParam = dyn_cast<FunctionDecl>(ParmVar->getDeclContext());
+  if (!FuncForParam)
+    return;
+  const FunctionTemplateDecl *FuncTemplate =
+      FuncForParam->getDescribedFunctionTemplate();
+  if (!FuncTemplate)
+    return;
+
+  // Check that the template type parameter belongs to the same function
+  // template as the function parameter of that type. (This implies that type
+  // deduction will happen on the type.)
+  const TemplateParameterList *Params = FuncTemplate->getTemplateParameters();
+  if (!llvm::is_contained(*Params, TypeParmDecl))
+    return;
+
+  const auto *Ctor = Result.Nodes.getNodeAs<CXXConstructorDecl>("ctor");
+  if (Ctor) {
+    // Every parameter after the first must have a default value.
+    for (auto Iter = Ctor->param_begin() + 1; Iter != Ctor->param_end(); ++Iter) {
+      if (!(*Iter)->hasDefaultArg())
+        return;
+    }
+
+    if (!Ctor->getParent()->hasUserDeclaredCopyConstructor()) {
+      diag(Ctor->getLocation(), "a copy constructor should be declared when there is a template constructor with a single parameter that is a generic parameter.");
+    }
+  }
+
+  const auto *CopyAssignOp = Result.Nodes.getNodeAs<CXXMethodDecl>("copy-assign");
+  if (CopyAssignOp) {
+    for (auto Iter = CopyAssignOp->param_begin() + 1; Iter != CopyAssignOp->param_end(); ++Iter) {
+      if (!(*Iter)->hasDefaultArg())
+        return;
+    }
+    if (!CopyAssignOp->getParent()->hasUserDeclaredCopyAssignment()) {
+      diag(CopyAssignOp->getLocation(), "a copy assignment operator should be declared when there is a template assignment operator with a parameter that is a generic parameter.");
+    } 
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/TemplateGenericParamCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/TemplateGenericParamCheck.h
@@ -1,0 +1,35 @@
+//===--- TemplateGenericParamCheck.h - clang-tidy ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_TEMPLATEGENERICPARAMCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_TEMPLATEGENERICPARAMCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that a copy constructor is declared when there is a template constructor with a single parameter that is a generic parameter.
+/// Checks that a copy assignment operator is declared when there is a template assignment operator with a parameter that is a generic parameter.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-template-generic-param.html
+class TemplateGenericParamCheck : public ClangTidyCheck {
+public:
+  TemplateGenericParamCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_TEMPLATEGENERICPARAMCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -280,17 +280,24 @@ New checks
 
   Warns if the default label is not last in a switch statement.
 
-- New :doc:`bsl-ternary-operator-forbidden
-  <clang-tidy/checks/bsl-ternary-operator-forbidden>` check.
-
-  Warns if you use the ternary operator
-
 - New :doc:`bsl-struct-def
   <clang-tidy/checks/bsl-struct-def>` check.
 
   Checks that a struct only contains public data members, does not provide any
   special member functions or methods, and is not a base or inherits from
   another struct or class
+
+- New :doc:`bsl-template-generic-param
+  <clang-tidy/checks/bsl-template-generic-param>` check.
+
+  Checks that a copy constructor/assignment operator is declared when there is a 
+  template constructor/assignment operator (respectively) with a single parameter
+  that is a generic parameter.
+
+- New :doc:`bsl-ternary-operator-forbidden
+  <clang-tidy/checks/bsl-ternary-operator-forbidden>` check.
+
+  Warns if you use the ternary operator
 
 - New :doc:`bsl-using-decl-scope
   <clang-tidy/checks/bsl-using-decl-scope>` check.

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-template-generic-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-template-generic-param.rst
@@ -1,0 +1,35 @@
+.. title:: clang-tidy - bsl-template-generic-param
+
+bsl-template-generic-param
+==========================
+
+Checks that a copy constructor is declared when there is a template constructor
+with a single parameter that is a generic parameter.
+Checks that a copy assignment operator is declared when there is a template 
+assignment operator with a parameter that is a generic parameter.
+
+Examples:
+
+.. code-block:: c++
+
+  class A {
+  public:
+    // Template constructor like copy constructor
+    template <typename T> A(T const &rhs) {}	// Non-compliant
+
+    // Like copy assignment
+    template <typename T> T &operator=(T const &rhs) { return *this; }	// Non-compliant
+  };
+
+  class B {
+  public:
+    // Copy constructor
+    B(const B &old_obj) {}
+    // Copy assignment
+    B &operator=(const B &other) {}
+
+    template <typename T> B(T const &rhs) {}
+
+    template <typename T> T &operator=(T const &rhs) { return *this; }
+  };
+

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -88,8 +88,9 @@ Clang-Tidy Checks
    `bsl-stmt-switch-case-parent <bsl-stmt-switch-case-parent.html>`_,
    `bsl-stmt-switch-default-break <bsl-stmt-switch-default-break.html>`_,
    `bsl-stmt-switch-default-last <bsl-stmt-switch-default-last.html>`_,
+   `bsl-struct-def <bsl-struct-def.html>`_,
+   `bsl-template-generic-param <bsl-template-generic-param.html>`_,
    `bsl-ternary-operator-forbidden <bsl-ternary-operator-forbidden.html>`_, "Yes"
-   `bsl-struct-def <bsl-struct-def.html>`_, "Yes"
    `bsl-types-fixed-width-ints <bsl-types-fixed-width-ints.html>`_,
    `bsl-types-no-wide-char <bsl-types-no-wide-char.html>`_,
    `bsl-unused-return-value <bsl-unused-return-value.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-template-generic-param.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-template-generic-param.cpp
@@ -1,0 +1,61 @@
+// RUN: %check_clang_tidy %s bsl-template-generic-param %t
+
+class A {
+public:
+  // Template constructor like copy constructor
+  template <typename T> A(T const &rhs) {}
+  // CHECK-MESSAGES: [[@LINE-1]]:25: warning: a copy constructor should be declared when there is a template constructor with a single parameter that is a generic parameter. [bsl-template-generic-param]
+
+  // Like copy assignment
+  template <typename T> T &operator=(T const &rhs) { return *this; }
+  // CHECK-MESSAGES: [[@LINE-1]]:28: warning: a copy assignment operator should be declared when there is a template assignment operator with a parameter that is a generic parameter. [bsl-template-generic-param]
+};
+
+class B {
+public:
+  // Copy constructor
+  B(const B &old_obj) {}
+  // Copy assignment
+  B &operator=(const B &other) {}
+
+  template <typename T> B(T const &rhs) {}
+
+  template <typename T> T &operator=(T const &rhs) { return *this; }
+};
+
+// Additional
+template <typename T> class C {
+public:
+  // Template type from class template, not from function template
+  template <typename Y> C(T const &rhs) {}
+
+  C &operator=(T const &rhs) { return *this; }
+};
+
+class D {
+public:
+  template <typename T> D(T myvar) {}
+  // CHECK-MESSAGES: [[@LINE-1]]:25: warning: a copy constructor should be declared when there is a template constructor with a single parameter that is a generic parameter. [bsl-template-generic-param]
+};
+
+template <typename T> class E {
+public:
+  template <typename Y> E(T myvar2) {}
+};
+
+template <typename T> class F {
+public:
+  template <typename Y> F(Y myvar2) {}
+  // CHECK-MESSAGES: [[@LINE-1]]:25: warning: a copy constructor should be declared when there is a template constructor with a single parameter that is a generic parameter. [bsl-template-generic-param]
+};
+
+class G {
+public:
+  // More than one parameter
+  template <typename T> G(T const &rhs, int i) {}
+
+  template <typename T> G(T const &rhs, T const &foo) {}
+
+  // Non-generic parameter
+  template <typename T> T &operator=(int i) { return *this; }
+};


### PR DESCRIPTION
M14-5-2, M14-5-3
Declare copy ctor/copy assignment operator when template ctor/copy assignment operator with a single generic parameter is declared