### PR TITLE
[clang-tidy] bsl-copy-move-access-specifier

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -14,6 +14,7 @@
 #include "ClassMemberInitCheck.h"
 #include "ClassMemberRedefinedCheck.h"
 #include "ClassVirtualBaseCheck.h"
+#include "CopyMoveAccessSpecifierCheck.h"
 #include "DeclForbiddenCheck.h"
 #include "DestructorAccessSpecifierCheck.h"
 #include "EnumExplicitCheck.h"
@@ -67,6 +68,8 @@ public:
         "bsl-class-member-redefined");
     CheckFactories.registerCheck<ClassVirtualBaseCheck>(
         "bsl-class-virtual-base");
+    CheckFactories.registerCheck<CopyMoveAccessSpecifierCheck>(
+        "bsl-copy-move-access-specifier");
     CheckFactories.registerCheck<DeclForbiddenCheck>(
         "bsl-decl-forbidden");
     CheckFactories.registerCheck<DestructorAccessSpecifierCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -8,6 +8,7 @@ add_clang_library(clangTidyBslModule
   ClassMemberInitCheck.cpp
   ClassMemberRedefinedCheck.cpp
   ClassVirtualBaseCheck.cpp
+  CopyMoveAccessSpecifierCheck.cpp
   DeclForbiddenCheck.cpp
   DestructorAccessSpecifierCheck.cpp
   EnumExplicitCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/CopyMoveAccessSpecifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/CopyMoveAccessSpecifierCheck.cpp
@@ -1,0 +1,56 @@
+//===--- CopyMoveAccessSpecifierCheck.cpp - clang-tidy --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CopyMoveAccessSpecifierCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+void CopyMoveAccessSpecifierCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      cxxConstructorDecl(anyOf(isCopyConstructor(), isMoveConstructor()),
+                         unless(anyOf(isDeleted(), isProtected())))
+          .bind("ctor"),
+      this);
+  Finder->addMatcher(cxxMethodDecl(anyOf(isCopyAssignmentOperator(),
+                                         isMoveAssignmentOperator()),
+                                   unless(anyOf(isDeleted(), isProtected())))
+                         .bind("op"),
+                     this);
+}
+
+void CopyMoveAccessSpecifierCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  const auto *VDecl = Result.Nodes.getNodeAs<CXXConstructorDecl>("ctor");
+  if (VDecl) {
+    auto LocV = VDecl->getLocation();
+    if (!VDecl->getParent()->isEffectivelyFinal())
+      diag(
+          LocV,
+          "Copy and move constructors shall be declared protected or defined "
+          "“=delete” in base class; otherwise declare non-base class as final");
+  }
+
+  const auto *MDecl = Result.Nodes.getNodeAs<CXXMethodDecl>("op");
+  if (MDecl) {
+    auto LocM = MDecl->getLocation();
+    if (!MDecl->getParent()->isEffectivelyFinal())
+      diag(LocM, "Copy and move assignment operators shall be declared "
+                 "protected or defined “=delete” in base class; otherwise "
+                 "declare non-base class as final");
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/CopyMoveAccessSpecifierCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/CopyMoveAccessSpecifierCheck.h
@@ -1,0 +1,35 @@
+//===--- CopyMoveAccessSpecifierCheck.h - clang-tidy ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_COPYMOVEACCESSSPECIFIERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_COPYMOVEACCESSSPECIFIERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that copy and move constructors and copy assignment and move
+/// assignment operators are declared protected or deleted in base class
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-copy-move-access-specifier.html
+class CopyMoveAccessSpecifierCheck : public ClangTidyCheck {
+public:
+  CopyMoveAccessSpecifierCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_COPYMOVEACCESSSPECIFIERCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -106,6 +106,12 @@ New checks
 
   Warns if a class has any virtual bases.
 
+- New :doc:`bsl-copy-move-access-specifier
+  <clang-tidy/checks/bsl-copy-move-access-specifier>` check.
+
+  Checks that copy and move constructors and copy assignment and move 
+  assignment operators are declared protected or deleted in base class.
+
 - New :doc:`bsl-decl-forbidden
   <clang-tidy/checks/bsl-decl-forbidden>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-copy-move-access-specifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-copy-move-access-specifier.rst
@@ -1,0 +1,64 @@
+.. title:: clang-tidy - bsl-copy-move-access-specifier
+
+bsl-copy-move-access-specifier
+==============================
+
+Checks that copy and move constructors and copy assignment and move 
+assignment operators are declared protected or deleted in base class.
+
+Example:
+
+.. code-block:: c++
+
+  // Abstract base class
+  class A {
+  public:
+    A() = default;
+    A(A const &) = default; // Non-compliant
+    A(A &&) = default;      // Non-compliant
+    virtual ~A() = 0;
+    A &operator=(A const &) = default; // Non-compliant
+    A &operator=(A &&) = default;      // Non-compliant
+  };
+
+  class B : public A {};
+
+  // Abstract base class
+  class C {
+  public:
+    C() = default;
+    virtual ~C() = 0;
+
+  protected: // All compliant
+    C(C const &) = default;
+    C(C &&) = default;
+    C &operator=(C const &) = default;
+    C &operator=(C &&) = default;
+  };
+
+  class D : public C {};
+
+  class E {
+  public:
+    E() = default;
+    virtual ~E() = 0;
+    E(E const &) = delete;            // Compliant
+    E(E &&) = delete;                 // Compliant
+    E &operator=(E const &) = delete; // Compliant
+    E &operator=(E &&) = delete;      // Compliant
+  };
+
+  class F : public E {};
+
+  // Non-abstract base class
+  class G {
+  public:
+    G() = default;
+    virtual ~G() = default;
+    G(G const &) = default;            // Non-compliant
+    G(G &&) = default;                 // Non-compliant
+    G &operator=(G const &) = default; // Non-compliant
+    G &operator=(G &&) = default;      // Non-compliant
+  };
+
+  class H : public G {};

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -50,6 +50,7 @@ Clang-Tidy Checks
    `bsl-class-member-init <bsl-class-member-init.html>`_,
    `bsl-class-member-redefined <bsl-class-member-redefined.html>`_,
    `bsl-class-virtual-base <bsl-class-virtual-base.html>`_,
+   `bsl-copy-move-access-specifier <bsl-copy-move-access-specifier.html>`_, "Yes"
    `bsl-decl-forbidden <bsl-decl-forbidden.html>`_,
    `bsl-destructor-access-specifier <bsl-destructor-access-specifier.html>`_, "Yes"
    `bsl-enum-explicit <bsl-enum-explicit.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-copy-move-access-specifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-copy-move-access-specifier.cpp
@@ -1,0 +1,114 @@
+// RUN: %check_clang_tidy %s bsl-copy-move-access-specifier %t
+
+// Abstract base class
+class A {
+public:
+  A() = default;
+  A(A const &) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  A(A &&) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  virtual ~A() = 0;
+  A &operator=(A const &) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  A &operator=(A &&) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+};
+
+class B : public A {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+// CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+
+// Abstract base class
+class C {
+public:
+  C() = default;
+  virtual ~C() = 0;
+
+protected: // All compliant
+  C(C const &) = default;
+  C(C &&) = default;
+  C &operator=(C const &) = default;
+  C &operator=(C &&) = default;
+};
+
+class D : public C {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+// CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+
+class E {
+public:
+  E() = default;
+  virtual ~E() = 0;
+  E(E const &) = delete;
+  E(E &&) = delete;
+  E &operator=(E const &) = delete;
+  E &operator=(E &&) = delete;
+};
+
+class F : public E {};
+
+// Non-abstract base class
+class G {
+public:
+  G() = default;
+  virtual ~G() = default;
+  G(G const &) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  G(G &&) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  G &operator=(G const &) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  G &operator=(G &&) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+};
+
+class H : public G {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+// CHECK-MESSAGES: :[[@LINE-2]]:7: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+
+// Abstract base class
+class I {
+public:
+  virtual void foo() = 0;
+  I(I const &) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  I(I &&) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: Copy and move constructors shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  I &operator=(I const &) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+  I &operator=(I &&) = default;
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Copy and move assignment operators shall be declared protected or defined “=delete” in base class; otherwise declare non-base class as final [bsl-copy-move-access-specifier]
+};
+
+// Abstract base class
+class J {
+public:
+  virtual void foo() = 0;
+
+protected:
+  J(J const &) = default;
+  J(J &&) = default;
+  J &operator=(J const &) = default;
+  J &operator=(J &&) = default;
+};
+
+// Abstract base class
+class K {
+public:
+  virtual void foo() = 0;
+  K(K const &) = delete;
+  K(K &&) = delete;
+  K &operator=(K const &) = delete;
+  K &operator=(K &&) = delete;
+};
+
+
+// Final class, non-base
+class L final {
+public:
+  L(L const &) = default;
+  L(L &&) = default;
+  L &operator=(L const &) = default;
+  L &operator=(L &&) = default;
+};


### PR DESCRIPTION
A12-8-6
Checks that copy and move constructors and copy assignment and move assignment operators are declared protected or deleted in base class