### PR TITLE
[clang-tidy] Add bsl-type-decl-header

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -58,6 +58,7 @@
 #include "StructDefCheck.h"
 #include "TemplateGenericParamCheck.h"
 #include "TernaryOperatorForbiddenCheck.h"
+#include "TypeDeclHeaderCheck.h"
 #include "TypesFixedWidthIntsCheck.h"
 #include "TypesNoWideCharCheck.h"
 #include "UnusedReturnValueCheck.h"
@@ -164,6 +165,8 @@ public:
         "bsl-template-generic-param");
     CheckFactories.registerCheck<TernaryOperatorForbiddenCheck>(
         "bsl-ternary-operator-forbidden");
+    CheckFactories.registerCheck<TypeDeclHeaderCheck>(
+        "bsl-type-decl-header");
     CheckFactories.registerCheck<TypesFixedWidthIntsCheck>(
         "bsl-types-fixed-width-ints");
     CheckFactories.registerCheck<LiteralsAsciiOnlyCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -52,6 +52,7 @@ add_clang_library(clangTidyBslModule
   StructDefCheck.cpp
   TemplateGenericParamCheck.cpp
   TernaryOperatorForbiddenCheck.cpp
+  TypeDeclHeaderCheck.cpp
   TypesFixedWidthIntsCheck.cpp
   TypesNoWideCharCheck.cpp
   UnusedReturnValueCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/TypeDeclHeaderCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/TypeDeclHeaderCheck.cpp
@@ -1,0 +1,50 @@
+//===--- TypeDeclHeaderCheck.cpp - clang-tidy -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeDeclHeaderCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+void TypeDeclHeaderCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(tagDecl(unless(hasAncestor(tagDecl()))).bind("tag"), this);
+}
+
+void TypeDeclHeaderCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<TagDecl>("tag");
+  SourceManager &SM = *Result.SourceManager;
+
+  StringRef TypeName = MatchedDecl->getName();
+
+  StringRef FileNameWithPath =
+      SM.getFilename(SM.getSpellingLoc(MatchedDecl->getLocation()));
+
+  const FileEntry *fe =
+      SM.getFileEntryForID(SM.getFileID(MatchedDecl->getLocation()));
+  StringRef filedir = fe->getDir()->getName();
+  if (FileNameWithPath.consume_back(StringRef(".h")) ||
+      FileNameWithPath.consume_back(StringRef(".hpp"))) {
+    // remove path
+    FileNameWithPath.consume_front(filedir);
+    FileNameWithPath.consume_front(StringRef("/"));
+    if (FileNameWithPath.compare(TypeName)) {
+      diag(MatchedDecl->getLocation(),
+           "declared type name %0 does not have same name as header file %1")
+          << TypeName << FileNameWithPath;
+    }
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/TypeDeclHeaderCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/TypeDeclHeaderCheck.h
@@ -1,0 +1,34 @@
+//===--- TypeDeclHeaderCheck.h - clang-tidy ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_TYPEDECLHEADERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_TYPEDECLHEADERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that type name declared in header file identical to file name
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-type-decl-header.html
+class TypeDeclHeaderCheck : public ClangTidyCheck {
+public:
+  TypeDeclHeaderCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_TYPEDECLHEADERCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -310,6 +310,11 @@ New checks
 
   Warns if you use the ternary operator
 
+- New :doc:`bsl-type-decl-header
+  <clang-tidy/checks/bsl-type-decl-header>` check.
+
+  Checks that type name declared in header file identical to file name.
+
 - New :doc:`bsl-using-decl-scope
   <clang-tidy/checks/bsl-using-decl-scope>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-type-decl-header.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-type-decl-header.rst
@@ -1,0 +1,24 @@
+.. title:: clang-tidy - bsl-type-decl-header
+
+bsl-type-decl-header
+====================
+
+Checks that type name declared in header file identical to file name.
+
+Examples:
+
+.. code-block:: c++
+
+  // Given header file name BSLTypeDeclHeader.hpp
+
+  class BSLTypeDeclHeader {
+    struct Inner {};
+
+    union InnerUnion {
+      enum InnerEnum { a };
+    };
+  };	// All compliant, including nested types
+
+  class NotBSLTypeDeclHeader {
+    struct Inner {};
+  };	// Non-compliant

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -93,6 +93,7 @@ Clang-Tidy Checks
    `bsl-struct-def <bsl-struct-def.html>`_,
    `bsl-template-generic-param <bsl-template-generic-param.html>`_,
    `bsl-ternary-operator-forbidden <bsl-ternary-operator-forbidden.html>`_, "Yes"
+   `bsl-type-decl-header <bsl-type-decl-header.html>`_, "Yes"
    `bsl-types-fixed-width-ints <bsl-types-fixed-width-ints.html>`_,
    `bsl-types-no-wide-char <bsl-types-no-wide-char.html>`_,
    `bsl-unused-return-value <bsl-unused-return-value.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeader.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeader.hpp
@@ -1,0 +1,64 @@
+// RUN: %check_clang_tidy %s bsl-type-decl-header %t
+// When running check_clang_tidy script, make sure that temp file name is test file name
+// ie, BSLTypeDeclHeader for this test
+
+// All compliant
+namespace n1 {
+// Function
+int BSLTypeDeclHeader(){};
+void foo(){};
+long bar = 0;
+} // namespace n1
+
+namespace n2 {
+// Type alias
+using BSLTypeDeclHeader = void;
+using bar = void;
+} // namespace n2
+
+namespace n3 {
+// Template type alias
+template <class T> using BSLTypeDeclHeader = T *;
+
+template <class T> using foo = T *;
+} // namespace n3
+
+namespace n4 {
+class BSLTypeDeclHeader {
+  struct Inner {};
+
+  union InnerUnion {
+    enum InnerEnum { a };
+  };
+};
+} // namespace n4
+
+namespace n5 {
+template <typename T> struct BSLTypeDeclHeader {
+  T foo;
+  struct Inner {
+    T innerfoo;
+  };
+
+  template <typename Y> struct InnerTemplate { Y innerfoo; };
+}; // Compliant
+} // namespace n5
+
+class C {
+  struct Inner {};
+
+  union InnerUnion {
+    enum InnerEnum { a };
+  };
+};
+// CHECK-MESSAGES: [[@LINE-7]]:7: warning: declared type name C does not have same name as header file BSLTypeDeclHeader [bsl-type-decl-header]
+
+template <typename T> struct S {
+  T foo;
+  struct Inner {
+    T innerfoo;
+  };
+
+  template <typename Y> struct InnerTemplate { Y innerfoo; };
+};
+// CHECK-MESSAGES: [[@LINE-8]]:30: warning: declared type name S does not have same name as header file BSLTypeDeclHeader [bsl-type-decl-header]

--- a/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderClass.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderClass.hpp
@@ -1,0 +1,17 @@
+// RUN: %check_clang_tidy %s bsl-type-decl-header %t
+
+class BSLTypeDeclHeaderClass { // Compliant
+  int foo;
+};
+
+class NotBSLTypeDeclHeaderClass {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning: declared type name NotBSLTypeDeclHeaderClass does not have same name as header file BSLTypeDeclHeaderClass [bsl-type-decl-header]
+
+namespace n1 {
+class BSLTypeDeclHeaderClass { // Compliant
+  class Inner {};              // Compliant
+};
+
+class NotBSLTypeDeclHeaderClass {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning: declared type name NotBSLTypeDeclHeaderClass does not have same name as header file BSLTypeDeclHeaderClass [bsl-type-decl-header]
+} // namespace n1

--- a/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderEnum.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderEnum.hpp
@@ -1,0 +1,13 @@
+// RUN: %check_clang_tidy %s bsl-type-decl-header %t
+
+enum BSLTypeDeclHeaderEnum { x, y, z }; // Compliant
+
+enum NotBSLTypeDeclHeaderEnum { a, b, c }; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:6: warning: declared type name NotBSLTypeDeclHeaderEnum does not have same name as header file BSLTypeDeclHeaderEnum [bsl-type-decl-header]
+
+namespace n1 {
+enum BSLTypeDeclHeaderEnum { u, v, w }; // Compliant
+
+enum NotBSLTypeDeclHeaderEnum { i, j, k }; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:6: warning: declared type name NotBSLTypeDeclHeaderEnum does not have same name as header file BSLTypeDeclHeaderEnum [bsl-type-decl-header]
+} // namespace n1

--- a/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderStruct.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderStruct.hpp
@@ -1,0 +1,18 @@
+// RUN: %check_clang_tidy %s bsl-type-decl-header %t
+
+struct BSLTypeDeclHeaderStruct { // Compliant
+  int x;
+};
+
+struct NotBSLTypeDeclHeaderStruct {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:8: warning: declared type name NotBSLTypeDeclHeaderStruct does not have same name as header file BSLTypeDeclHeaderStruct [bsl-type-decl-header]
+
+namespace n1 {
+struct BSLTypeDeclHeaderStruct { // Compliant
+  int x;
+  struct Inner {}; // Compliant
+};
+
+struct NotBSLTypeDeclHeaderStruct {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:8: warning: declared type name NotBSLTypeDeclHeaderStruct does not have same name as header file BSLTypeDeclHeaderStruct [bsl-type-decl-header]
+} // namespace n1

--- a/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderTemplateClass.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderTemplateClass.hpp
@@ -1,0 +1,26 @@
+// RUN: %check_clang_tidy %s bsl-type-decl-header %t
+
+template <typename T> class BSLTypeDeclHeaderTemplateClass {
+  T foo;
+}; // Compliant
+
+template <typename T>
+class NotBSLTypeDeclHeaderTemplateClass {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning: declared type name NotBSLTypeDeclHeaderTemplateClass does not have same name as header file BSLTypeDeclHeaderTemplateClass [bsl-type-decl-header]
+
+namespace n1 {
+template <typename T> class BSLTypeDeclHeaderTemplateClass {
+  T foo;
+  class Inner { // Compliant
+    T innerfoo;
+  };
+
+  template <typename Y> class InnerTemplate { // Compliant
+    Y innerfoo;
+  };
+}; // Compliant
+
+template <typename T>
+class NotBSLTypeDeclHeaderTemplateClass {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning: declared type name NotBSLTypeDeclHeaderTemplateClass does not have same name as header file BSLTypeDeclHeaderTemplateClass [bsl-type-decl-header]
+} // namespace n1

--- a/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderTemplateStruct.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderTemplateStruct.hpp
@@ -1,0 +1,25 @@
+// RUN: %check_clang_tidy %s bsl-type-decl-header %t
+
+template <typename T> struct BSLTypeDeclHeaderTemplateStruct {
+  T foo;
+}; // Compliant
+
+template <typename T>
+struct NotBSLTypeDeclHeaderTemplateStruct {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:8: warning: declared type name NotBSLTypeDeclHeaderTemplateStruct does not have same name as header file BSLTypeDeclHeaderTemplateStruct [bsl-type-decl-header]
+namespace n1 {
+template <typename T> struct BSLTypeDeclHeaderTemplateStruct {
+  T foo;
+  struct Inner { // Compliant
+    T innerfoo;
+  };
+
+  template <typename Y> struct InnerTemplate { // Compliant
+    Y innerfoo;
+  };
+}; // Compliant
+
+template <typename T>
+struct NotBSLTypeDeclHeaderTemplateStruct {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:8: warning: declared type name NotBSLTypeDeclHeaderTemplateStruct does not have same name as header file BSLTypeDeclHeaderTemplateStruct [bsl-type-decl-header]
+} // namespace n1

--- a/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderTypedef.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderTypedef.hpp
@@ -1,0 +1,53 @@
+// RUN: %check_clang_tidy %s bsl-type-decl-header %t
+
+typedef struct {
+  int a;
+  int b;
+} BSLTypeDeclHeaderTypedef; // Compliant
+
+typedef long NotBSLTypeDeclHeaderTypedef; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning:
+
+void foo() {
+  typedef int foo; // Compliant
+}
+
+template <typename T> struct S {
+  typedef const T foo; // Compliant
+};
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning:
+
+template <typename T> class C {
+  typedef long foo; // Compliant
+};
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning:
+
+namespace n1 {
+typedef struct {
+  int a;
+  int b;
+} BSLTypeDeclHeaderTypedef; // Compliant
+
+typedef long NotBSLTypeDeclHeaderTypedef; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning:
+} // namespace n1
+
+namespace n2 {
+typedef void (*BSLTypeDeclHeaderTypedef)(int arg1); // Compliant
+
+void foo(int x) {}
+
+BSLTypeDeclHeaderTypedef ref = &foo;
+} // namespace n2
+
+namespace n3 {
+template <typename T> struct BSLTypeDeclHeaderTypedef {
+  typedef const T foo; // Compliant
+};
+} // namespace n3
+
+namespace n4 {
+template <typename T> class BSLTypeDeclHeaderTypedef {
+  typedef long foo; // Compliant
+};
+} // namespace n4

--- a/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderUnion.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/BSLTypeDeclHeaderUnion.hpp
@@ -1,0 +1,18 @@
+// RUN: %check_clang_tidy %s bsl-type-decl-header %t
+
+union BSLTypeDeclHeaderUnion { // Compliant
+  int x;
+};
+
+union NotBSLTypeDeclHeaderUnion {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning: declared type name NotBSLTypeDeclHeaderUnion does not have same name as header file BSLTypeDeclHeaderUnion [bsl-type-decl-header]
+
+namespace n1 {
+union BSLTypeDeclHeaderUnion { // Compliant
+  int x;
+  union Inner {}; // Compliant
+};
+
+union NotBSLTypeDeclHeaderUnion {}; // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:7: warning: declared type name NotBSLTypeDeclHeaderUnion does not have same name as header file BSLTypeDeclHeaderUnion [bsl-type-decl-header]
+} // namespace n1


### PR DESCRIPTION
A2-9-1
A header file name shall be identical to a type name declared in it if it declares a type.