### PR TITLE
[clang-tidy] Add bsl-forward-reference-overloaded

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/BslTidyModule.cpp
@@ -27,6 +27,7 @@
 #include "EnumInitCheck.h"
 #include "EnumScopedCheck.h"
 #include "ForLoopCounterCheck.h"
+#include "ForwardReferenceOverloadedCheck.h"
 #include "FunctionNameUseCheck.h"
 #include "FunctionNoexceptCheck.h"
 #include "IdentifierTypographicallyUnambiguousCheck.h"
@@ -103,6 +104,8 @@ public:
         "bsl-enum-scoped");
     CheckFactories.registerCheck<ForLoopCounterCheck>(
         "bsl-for-loop-counter");
+    CheckFactories.registerCheck<ForwardReferenceOverloadedCheck>(
+        "bsl-forward-reference-overloaded");
     CheckFactories.registerCheck<FunctionNameUseCheck>(
         "bsl-function-name-use");
     CheckFactories.registerCheck<FunctionNoexceptCheck>(

--- a/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bsl/CMakeLists.txt
@@ -21,6 +21,7 @@ add_clang_library(clangTidyBslModule
   EnumInitCheck.cpp
   EnumScopedCheck.cpp
   ForLoopCounterCheck.cpp
+  ForwardReferenceOverloadedCheck.cpp
   FunctionNameUseCheck.cpp
   FunctionNoexceptCheck.cpp
   IdentifierTypographicallyUnambiguousCheck.cpp

--- a/clang-tools-extra/clang-tidy/bsl/ForwardReferenceOverloadedCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/ForwardReferenceOverloadedCheck.cpp
@@ -1,0 +1,135 @@
+//===--- ForwardReferenceOverloadedCheck.cpp - clang-tidy -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ForwardReferenceOverloadedCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+AST_MATCHER(FunctionDecl, isCopyOrMove) {
+  if (isa<CXXConstructorDecl>(&Node)) {
+    return dyn_cast<CXXConstructorDecl>(&Node)->isCopyOrMoveConstructor();
+  } else if (isa<CXXMethodDecl>(&Node)) {
+    return dyn_cast<CXXMethodDecl>(&Node)->isCopyAssignmentOperator() ||
+           dyn_cast<CXXMethodDecl>(&Node)->isMoveAssignmentOperator();
+  }
+  return false;
+}
+
+void ForwardReferenceOverloadedCheck::registerMatchers(MatchFinder *Finder) {
+  auto ForwardingReferenceParmMatcher =
+      parmVarDecl(
+          hasType(qualType(rValueReferenceType(),
+                           references(templateTypeParmType(hasDeclaration(
+                               templateTypeParmDecl().bind("type-parm-decl")))),
+                           unless(references(qualType(isConstQualified()))))))
+          .bind("parm-var");
+  Finder->addMatcher(ForwardingReferenceParmMatcher, this);
+
+  Finder->addMatcher(
+      functionDecl(unless(anyOf(hasAnyParameter(ForwardingReferenceParmMatcher),
+                                isDeleted(), isCopyOrMove())))
+          .bind("other"),
+      this);
+}
+
+void ForwardReferenceOverloadedCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  auto Mgr = Result.SourceManager;
+
+  // Match functions that definitely do not have forwarding references
+  const auto *Function = Result.Nodes.getNodeAs<FunctionDecl>("other");
+
+  bool isForwardRef = true;
+
+  const FunctionDecl *FunctionRef;
+  if (Function) {
+    isForwardRef = false;
+    FunctionRef = Function;
+  } else {
+    const auto *ParmVar = Result.Nodes.getNodeAs<ParmVarDecl>("parm-var");
+    const auto *TypeParmDecl =
+        Result.Nodes.getNodeAs<TemplateTypeParmDecl>("type-parm-decl");
+
+    isForwardRef = true;
+
+    // Get the FunctionDecl and FunctionTemplateDecl containing the function
+    // parameter.
+    const auto *FuncForParam =
+        dyn_cast<FunctionDecl>(ParmVar->getDeclContext());
+    if (!FuncForParam)
+      return;
+    const FunctionTemplateDecl *FuncTemplate =
+        FuncForParam->getDescribedFunctionTemplate();
+    if (!FuncTemplate)
+      isForwardRef = false;
+
+    // Check that the template type parameter belongs to the same function
+    // template as the function parameter of that type. (This implies that type
+    // deduction will happen on the type.)
+    const TemplateParameterList *Params = FuncTemplate->getTemplateParameters();
+    if (!llvm::is_contained(*Params, TypeParmDecl))
+      isForwardRef = false;
+
+    FunctionRef = FuncForParam;
+  }
+
+  std::string funcname = FunctionRef->getQualifiedNameAsString();
+
+  auto itr = overloadedFunctions.find(funcname);
+  if (itr != overloadedFunctions.end()) {
+    std::vector<const FunctionDecl *> collision_vec = itr->second;
+    for (auto collision : collision_vec) {
+      if (collision->getNumParams() == FunctionRef->getNumParams()) {
+        unsigned int locnum =
+            Mgr->getPresumedLoc(collision->getLocation()).getLine();
+        diag(FunctionRef->getLocation(),
+             "function %0 overloads function declaration with forwarding "
+             "reference on line %1")
+            << funcname << locnum;
+        break;
+      }
+    }
+    // Nit: only add if no collision, but this will get cleaned up anyway
+    overloadedFunctions[funcname].push_back(FunctionRef);
+  } else if (isForwardRef) {
+    overloadedFunctions[funcname] = {FunctionRef};
+
+    // Check nonForwardRefFunctions for existing violations
+    auto nonforward_itr = nonForwardRefFunctions.find(funcname);
+    if (nonforward_itr != nonForwardRefFunctions.end()) {
+      std::vector<const FunctionDecl *> collision_vec = nonforward_itr->second;
+      for (auto collision : collision_vec) {
+        if (collision->getNumParams() == FunctionRef->getNumParams()) {
+          unsigned int locnum =
+              Mgr->getPresumedLoc(FunctionRef->getLocation()).getLine();
+          diag(collision->getLocation(),
+               "function %0 overloads function declaration with forwarding "
+               "reference on line %1")
+              << collision->getQualifiedNameAsString() << locnum;
+        }
+      }
+    }
+  } else { // Not a forwarding reference; add to nonForwardRef list
+    auto nonforward_itr = nonForwardRefFunctions.find(funcname);
+    if (nonforward_itr != nonForwardRefFunctions.end()) {
+      nonforward_itr->second.push_back(FunctionRef);
+    } else {
+      nonForwardRefFunctions[funcname] = {FunctionRef};
+    }
+  }
+}
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/bsl/ForwardReferenceOverloadedCheck.h
+++ b/clang-tools-extra/clang-tidy/bsl/ForwardReferenceOverloadedCheck.h
@@ -1,0 +1,47 @@
+//===--- ForwardReferenceOverloadedCheck.h - clang-tidy ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORWARDREFERENCEOVERLOADEDCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORWARDREFERENCEOVERLOADEDCHECK_H
+
+#include "../ClangTidyCheck.h"
+#include <unordered_map>
+#include <vector>
+
+namespace clang {
+namespace tidy {
+namespace bsl {
+
+/// Checks that a function that containing a “forwarding reference” as its
+/// argument is not overloaded unless the overload has a different number of
+/// parameters
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/bsl-forward-reference-overloaded.html
+class ForwardReferenceOverloadedCheck : public ClangTidyCheck {
+public:
+  ForwardReferenceOverloadedCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus11;
+  }
+
+private:
+  std::unordered_map<std::string, std::vector<const FunctionDecl *>>
+      overloadedFunctions;
+  std::unordered_map<std::string, std::vector<const FunctionDecl *>>
+      nonForwardRefFunctions;
+};
+
+} // namespace bsl
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BSL_FORWARDREFERENCEOVERLOADEDCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -160,6 +160,12 @@ New checks
   warn if else is used when it shouldn't be, which would prevent the above
   checks from working correctly.
 
+- New :doc:`bsl-forward-reference-overloaded
+  <clang-tidy/checks/bsl-forward-reference-overloaded>` check.
+
+  Checks that a function that containing a “forwarding reference” as its argument 
+  is not overloaded unless the overload has a different number of parameters
+
 - New :doc:`bsl-function-name-use
   <clang-tidy/checks/bsl-function-name-use>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bsl-forward-reference-overloaded.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bsl-forward-reference-overloaded.rst
@@ -1,0 +1,27 @@
+.. title:: clang-tidy - bsl-forward-reference-overloaded
+
+bsl-forward-reference-overloaded
+================================
+
+Checks that a function that containing a “forwarding reference” as its argument is not overloaded unless the overload has a different number of parameters
+
+Example:
+
+.. code-block:: c++
+
+  template <typename T> void f1(T &&t) {}
+
+  void f1(int &&t) {} // Non-compliant
+
+  void f1(int x, int &&t) {} // Compliant
+
+  template <typename T> void f1(T &&t, int a, int b) {} // Compliant
+
+  template <typename T> void f2(T &&t) {}
+
+  void f2(int &) = delete; // Compliant by deletion
+
+  template <typename T> void f3(T &&t, int a, int b) {} // Compliant
+
+  template <typename T>
+  void f3(T &&t, T &&y, int b) {} // Non-compliant, same number of params

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -46,7 +46,7 @@ Clang-Tidy Checks
    `android-comparison-in-temp-failure-retry <android-comparison-in-temp-failure-retry.html>`_,
    `boost-use-to-string <boost-use-to-string.html>`_, "Yes"
    `bsl-assign-op-decl-ref-qualifier <bsl-assign-op-decl-ref-qualifier.html>`_, "Yes"
-   `bsl-auto-type-usage <bsl-auto-type-usage.html>`_, "Yes"
+   `bsl-auto-type-usage <bsl-auto-type-usage.html>`_,
    `bsl-boolean-operators-forbidden <bsl-boolean-operators-forbidden.html>`_,
    `bsl-class-base <bsl-class-base.html>`_,
    `bsl-class-final-function <bsl-class-final-function.html>`_,
@@ -55,7 +55,7 @@ Clang-Tidy Checks
    `bsl-class-virtual-base <bsl-class-virtual-base.html>`_,
    `bsl-comparison-operators-forbidden <bsl-comparison-operators-forbidden.html>`_,
    `bsl-copy-move-access-specifier <bsl-copy-move-access-specifier.html>`_,
-   `bsl-const-obj-std-move <bsl-const-obj-std-move.html>`_, "Yes"
+   `bsl-const-obj-std-move <bsl-const-obj-std-move.html>`_,
    `bsl-decl-forbidden <bsl-decl-forbidden.html>`_,
    `bsl-destructor-access-specifier <bsl-destructor-access-specifier.html>`_,
    `bsl-else-required-after-if <bsl-else-required-after-if.html>`_,
@@ -63,8 +63,9 @@ Clang-Tidy Checks
    `bsl-enum-init <bsl-enum-init.html>`_,
    `bsl-enum-scoped <bsl-enum-scoped.html>`_,
    `bsl-for-loop-counter <bsl-for-loop-counter.html>`_,
+   `bsl-forward-reference-overloaded <bsl-forward-reference-overloaded.html>`_,
    `bsl-function-name-use <bsl-function-name-use.html>`_, "Yes"
-   `bsl-function-noexcept <bsl-function-noexcept.html>`_, "Yes"
+   `bsl-function-noexcept <bsl-function-noexcept.html>`_,
    `bsl-identifier-typographically-unambiguous <bsl-identifier-typographically-unambiguous.html>`_,
    `bsl-lambda-implicit-capture <bsl-lambda-implicit-capture.html>`_,
    `bsl-lambda-param-list <bsl-lambda-param-list.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/bsl-forward-reference-overloaded.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bsl-forward-reference-overloaded.cpp
@@ -1,0 +1,71 @@
+// RUN: %check_clang_tidy %s bsl-forward-reference-overloaded %t
+
+template <typename T> void f1(T &&t) {}
+
+// Overloading a function with forwarding reference
+void f1(int &&t) {} // Non-compliant
+// CHECK-MESSAGES: [[@LINE-1]]:6: warning: function f1 overloads function declaration with forwarding reference on line 3 [bsl-forward-reference-overloaded]
+
+void f1(int x, int &&t) {} // Compliant
+
+template <typename T> void f1(T &&t, int a, int b) {} // Compliant
+
+template <typename T> void f2(T &&t) {}
+
+void f2(int &) = delete; // Compliant by exception
+
+template <typename T> void f3(T &&t, int a, int b) {} // Compliant
+
+template <typename T>
+void f3(T &&t, T &&y, int b) {} // Non-compliant, same number of params
+// CHECK-MESSAGES: [[@LINE-1]]:6: warning: function f3 overloads function declaration with forwarding reference on line 17 [bsl-forward-reference-overloaded]
+
+class A {
+  template <typename T> void f1(T &&t) {}
+
+  void f1(int &&t) {} // Non-compliant
+  // CHECK-MESSAGES: [[@LINE-1]]:8: warning: function A::f1 overloads function declaration with forwarding reference on line 24 [bsl-forward-reference-overloaded]
+
+  template <typename T> void f2(T &&t) {}
+
+  void f2(int &) = delete; // Compliant by deletion
+
+  // Ignore move and copy
+  A( const A& other);
+  A& operator=(const A& other);
+  A(A&& other);
+  A& operator=(A&& other);
+};
+
+// Not forward references
+void f4(A &&a) {}
+
+void f4(int &) = delete; // Compliant
+
+void f5(A &&a) {}
+
+void f5(int &&a) {} // Compliant
+
+namespace n1 {
+void f1(int &&t) {} // Non-compliant with f1(T &&t)
+// CHECK-MESSAGES: [[@LINE-1]]:6: warning: function n1::f1 overloads function declaration with forwarding reference on line 55 [bsl-forward-reference-overloaded]
+
+void f1(int x, int &&t) {} // Compliant
+
+template <typename T> void f1(T &&t) {}
+
+void f1(long &&t) {} // Non-compliant with f1(T &&t)
+// CHECK-MESSAGES: [[@LINE-1]]:6: warning: function n1::f1 overloads function declaration with forwarding reference on line 55 [bsl-forward-reference-overloaded]
+
+template <typename T> void f1(T &&t, int a, int b) {} // Compliant
+
+template <typename T> void f2(T &&t) {}
+
+void f2(int &) = delete; // Compliant by deletion
+
+template <typename T> void f3(T &&t, int a, int b) {} // Compliant
+
+template <typename T>
+void f3(T &&t, T &&y, int b) {} // Non-compliant, same number of params
+// CHECK-MESSAGES: [[@LINE-1]]:6: warning: function n1::f3 overloads function declaration with forwarding reference on line 66 [bsl-forward-reference-overloaded]
+} // namespace n1


### PR DESCRIPTION
A13-3-1
Checks that a function that containing a “forwarding reference” as its argument is not overloaded unless the overload has a different number of parameters