### PR TITLE
Fix bsl-non-safe-integral-types-are-forbidden

### DIFF
--- a/clang-tools-extra/clang-tidy/bsl/NonSafeIntegralTypesAreForbiddenCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bsl/NonSafeIntegralTypesAreForbiddenCheck.cpp
@@ -134,6 +134,16 @@ void NonSafeIntegralTypesAreForbiddenCheck::check_field_decl(const MatchFinder::
   if (Record->isStruct())
     return;
 
+  auto const *DC = Record->getParent();
+  while (!isa<TranslationUnitDecl>(Decl::castFromDeclContext(DC))) {
+    if (const auto *Rec = dyn_cast<RecordDecl>(DC)) {
+      if (Rec->isStruct()) {
+        return;
+      }
+    }
+    DC = DC->getParent();
+  }
+
   auto const QT = FD->getType().getNonReferenceType().getCanonicalType().getUnqualifiedType();
   if (!QT->isIntegerType())
     return;


### PR DESCRIPTION
Non-safe integral types are forbidden except when declared within a
struct. The current check is done on the direct parent of a declaration
being a struct which is missing the case of when a struct is further up
the ancestry.

For example, non-safe integral field declared within a union or any
nested unions, all descendants of a struct would cause the following
warning (treated as an error here) to trigger:

```
error: integral types like int, std::int32_t and bsl::int32 are forbidden. Use bsl::safe_integral instead of 'bsl::uint64' [bsl-non-safe-integral-types-are-forbidden,-warnings-as-errors]
            bsl::uint64 reg0;
            ^
```